### PR TITLE
Configurable xpath to Signature, and extractor for saml:Assertion node

### DIFF
--- a/lib/passport-wsfed-saml2/saml.js
+++ b/lib/passport-wsfed-saml2/saml.js
@@ -12,6 +12,9 @@ var SAML = function (options) {
   if (!options.cert && !options.thumbprint) {
     throw new Error('You should set either a base64 encoded certificate or the thumbprint of the certificate');
   }
+    if(!options.signaturePath){
+        options.signaturePath = "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']";
+    }
 };
 
 SAML.prototype.certToPEM = function (cert) {
@@ -24,7 +27,7 @@ SAML.prototype.certToPEM = function (cert) {
 SAML.prototype.validateSignature = function (xml, cert, thumbprint) {
   var self = this;
   var doc = new xmldom.DOMParser().parseFromString(xml);
-  var signature = xmlCrypto.xpath.SelectNodes(doc, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
+  var signature = xmlCrypto.xpath.SelectNodes(doc, this.options.signaturePath)[0];
   var sig = new xmlCrypto.SignedXml(null, { idAttribute: 'AssertionID' });
   sig.keyInfoProvider = {
     getKeyInfo: function (key) {
@@ -126,7 +129,11 @@ SAML.prototype.validateResponse = function (samlAssertionString, callback) {
 
   var parser = new xml2js.Parser();
   parser.parseString(samlAssertionString, function (err, samlAssertion) {
-    
+
+    if(self.options.extractSAMLAssertion){
+        samlAssertion = self.options.extractSAMLAssertion(samlAssertion)
+    }
+
     var version;
     if (samlAssertion['@'].MajorVersion === '1')
       version = '1.1';


### PR DESCRIPTION
I modified saml.js so that the implementer can configure both the xpath to the Signature node and add a callback to return the saml:Assertion node.  In my case, both of these existed in different locations in the saml xml that I'm consuming.

By default, both the Signature and the Assertions will be extracted as they were in the original code.

If you do accept the changes it would be great if you could push them to npm. If you would like additional changes or documentation please let me know.

Thanks,

David Boardman
