### PR TITLE
Update to get the request back from the Passport Strategy

### DIFF
--- a/lib/passport-wsfed-saml2/strategy.js
+++ b/lib/passport-wsfed-saml2/strategy.js
@@ -99,7 +99,6 @@ Strategy.prototype._authenticate_jwt = function (req) {
     } else {
       self._verify(profile, verified);
     }
-    //self._verify(profile, verified);
   });
 };
 
@@ -148,7 +147,6 @@ Strategy.prototype.authenticate = function (req, opts) {
         } else {
           self._verify(profile, verified);
         }
-        //self._verify(profile, verified);
       });
     } else {
       // Initiate new samlp authentication request

--- a/lib/passport-wsfed-saml2/strategy.js
+++ b/lib/passport-wsfed-saml2/strategy.js
@@ -29,7 +29,6 @@ function Strategy (options, verify) {
   } else {
     this.passReqToCallback = false;
   }
-  //console.log('In WSFED Strategy. passReqToCallback = ' + this.passReqToCallback);
 
   if (!this.options.jwt) {
     this._saml = new saml.SAML(this.options);
@@ -72,7 +71,6 @@ Strategy.prototype._authenticate_saml = function (req) {
     } else {
       self._verify(profile, verified);
     }
-    //self._verify(profile, verified);
   });
 };
 

--- a/lib/passport-wsfed-saml2/strategy.js
+++ b/lib/passport-wsfed-saml2/strategy.js
@@ -24,6 +24,13 @@ function Strategy (options, verify) {
   passport.Strategy.call(this);
 
   this._verify = verify;
+  if(this.options.passReqToCallback) {
+    this.passReqToCallback = this.options.passReqToCallback;
+  } else {
+    this.passReqToCallback = false;
+  }
+  //console.log('In WSFED Strategy. passReqToCallback = ' + this.passReqToCallback);
+
   if (!this.options.jwt) {
     this._saml = new saml.SAML(this.options);
     this._samlp =  new samlp(this.options, this._saml);
@@ -60,7 +67,12 @@ Strategy.prototype._authenticate_saml = function (req) {
       self.success(user, info);
     };
 
-    self._verify(profile, verified);
+    if (self.passReqToCallback) {
+      self._verify(req, profile, verified);
+    } else {
+      self._verify(profile, verified);
+    }
+    //self._verify(profile, verified);
   });
 };
 
@@ -84,7 +96,12 @@ Strategy.prototype._authenticate_jwt = function (req) {
       self.success(user, info);
     };
 
-    self._verify(profile, verified);
+    if (self.passReqToCallback) {
+      self._verify(req, profile, verified);
+    } else {
+      self._verify(profile, verified);
+    }
+    //self._verify(profile, verified);
   });
 };
 
@@ -128,7 +145,12 @@ Strategy.prototype.authenticate = function (req, opts) {
           self.success(user, info);
         };
 
-        self._verify(profile, verified);
+        if (self.passReqToCallback) {
+          self._verify(req, profile, verified);
+        } else {
+          self._verify(profile, verified);
+        }
+        //self._verify(profile, verified);
       });
     } else {
       // Initiate new samlp authentication request


### PR DESCRIPTION
Update to get the request back from the Passport Strategy back to the caller.

This helps to take further custom action based on the request parameters and headers.