### PR TITLE
Added check for an additional namespace (WIF) while extracting token

### DIFF
--- a/lib/passport-wsfed-saml2/wsfederation.js
+++ b/lib/passport-wsfed-saml2/wsfederation.js
@@ -30,6 +30,11 @@ WsFederation.prototype = {
   extractToken: function(req) {
     var doc = new xmldom.DOMParser().parseFromString(req.body['wresult']);
     var token = doc.getElementsByTagNameNS('http://schemas.xmlsoap.org/ws/2005/02/trust', 'RequestedSecurityToken')[0];
+
+    //if the token was not found, search for the namespace that WIF sets
+    if(!token) {
+      token = doc.getElementsByTagNameNS('http://docs.oasis-open.org/ws-sx/ws-trust/200512', 'RequestedSecurityToken')[0];
+    }
   
     return token && token.firstChild;
   }


### PR DESCRIPTION
If the tokens are coming from a third party STS server (eg. Thinktecture Identity Server), Windows Identity Foundation (WIF) sets a different name space for the token. The token is exactly the same, just the name space is different from the current implementation.