### PR TITLE
remove passport-azure-acs dependancy

### DIFF
--- a/examples/auth0/package.json
+++ b/examples/auth0/package.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "express": ">= 0.0.0",
     "ejs": ">= 0.0.0",
-    "passport": ">= 0.0.0",
-    "passport-azure-acs": ">= 0.0.0"
+    "passport": ">= 0.0.0"
   }
 }

--- a/examples/login/package.json
+++ b/examples/login/package.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "express": ">= 0.0.0",
     "ejs": ">= 0.0.0",
-    "passport": ">= 0.0.0",
-    "passport-azure-acs": ">= 0.0.0"
+    "passport": ">= 0.0.0"
   }
 }


### PR DESCRIPTION
remove passport-azure-acs dependancy that is neither used or available.
