### PR TITLE
Updated passport library to validate the recipent attribute. We've al…

### DIFF
--- a/lib/passport-wsfed-saml2/saml.js
+++ b/lib/passport-wsfed-saml2/saml.js
@@ -21,6 +21,7 @@ var SAML = function (options) {
 
   this.options.checkExpiration = (typeof this.options.checkExpiration !== 'undefined') ? this.options.checkExpiration : true;
   this.options.checkAudience = (typeof this.options.checkAudience !== 'undefined') ? this.options.checkAudience : true;
+  this.options.checkRecipient = (typeof this.options.checkRecipient !== 'undefined') ? this.options.checkRecipient : true;
 };
 
 SAML.prototype.certToPEM = function (cert) {
@@ -111,10 +112,10 @@ SAML.prototype.validateExpiration = function (samlAssertion, version) {
   if (!conditions || conditions.length === 0) return false;
 
   var notBefore = new Date(conditions[0].getAttribute('NotBefore'));
-  notBefore = notBefore.setMinutes(notBefore.getMinutes() - 10); // 10 minutes clock skew
+  notBefore = notBefore.setMinutes(notBefore.getMinutes() - 5); // 5 minutes clock skew
 
   var notOnOrAfter = new Date(conditions[0].getAttribute('NotOnOrAfter'));
-  notOnOrAfter = notOnOrAfter.setMinutes(notOnOrAfter.getMinutes() + 10); // 10 minutes clock skew
+  notOnOrAfter = notOnOrAfter.setMinutes(notOnOrAfter.getMinutes() + 5); // 5 minutes clock skew
   var now = new Date();
 
   if (now < notBefore || now > notOnOrAfter)
@@ -133,6 +134,19 @@ SAML.prototype.validateAudience = function (samlAssertion, realm, version) {
 
   if (!audience || audience.length === 0) return false;
   return cryptiles.fixedTimeComparison(audience[0].textContent, realm);
+};
+
+SAML.prototype.validateRecipient = function(samlAssertion, recipientUrl){
+  var subjectConfirmationData = xpath.select("//*[local-name(.)='Subject']/*[local-name(.)='SubjectConfirmation']/*[local-name(.)='SubjectConfirmationData']", samlAssertion);
+  
+  // subjectConfirmationData is optional in the spec. Only validate if the assertion contains a recipient
+  if (!subjectConfirmationData || subjectConfirmationData.length === 0){ 
+    return true;
+  }
+
+  var recipient = subjectConfirmationData[0].getAttribute('Recipient');
+
+  return !recipient || recipient === recipientUrl;
 };
 
 SAML.prototype.parseAttributes = function (samlAssertion, version) {
@@ -245,7 +259,6 @@ SAML.prototype.parseAttributes = function (samlAssertion, version) {
 
 SAML.prototype.validateSamlAssertion = function (samlAssertion, callback) {
   var self = this;
-
   if (typeof samlAssertion === 'string')
     samlAssertion = new xmldom.DOMParser().parseFromString(samlAssertion);
 
@@ -264,7 +277,7 @@ SAML.prototype.parseAssertion = function(samlAssertion, callback) {
   if (self.options.extractSAMLAssertion){
       samlAssertion = self.options.extractSAMLAssertion(samlAssertion);
   }
-
+  
   if (typeof samlAssertion === 'string')
     samlAssertion = new xmldom.DOMParser().parseFromString(samlAssertion).documentElement;
 
@@ -284,8 +297,11 @@ SAML.prototype.parseAssertion = function(samlAssertion, callback) {
   }
 
   if (self.options.checkAudience && !self.validateAudience(samlAssertion, self.options.realm, version)) {
-    console.log('Audience is invalid. Configured: ' + self.options.realm);
     return callback(new Error('Audience is invalid. Configured: ' + self.options.realm), null);
+  }
+
+  if (self.options.checkRecipient && !self.validateRecipient(samlAssertion, self.options.recipientUrl)) {
+    return callback(new Error('Recipient is invalid. Configured: ' + self.options.recipientUrl), null);
   }
 
   var profile = self.parseAttributes(samlAssertion, version);

--- a/lib/passport-wsfed-saml2/samlp.js
+++ b/lib/passport-wsfed-saml2/samlp.js
@@ -286,11 +286,28 @@ Samlp.prototype = {
     return status;
   },
 
-  validateSamlResponse: function (samlResponse, callback) {
+  validateSamlResponse: function (samlResponse, options, callback) {
+    if (typeof options === 'function'){
+      callback = options;
+      options = null;
+    }
+
     var self = this;
 
     if (typeof samlResponse === 'string') {
       samlResponse = new xmldom.DOMParser().parseFromString(samlResponse);
+    }
+
+    // Check that the saml Resopnse actually has a Response object
+    var responseXML = xpath.select("//*[local-name(.)='Response']", samlResponse)[0];
+    if (!responseXML){ 
+      return callback(new Error('XML is not a valid saml response'));
+    }
+
+    var destination = responseXML.getAttribute('Destination');
+    // Check that the destintation attributes matches the recipientUrl (if configured)
+    if (options && options.checkDestination && destination && destination !== options.recipientUrl){
+      return callback(new Error('Destination endpoint ' + destination + ' did not match ' + options.recipientUrl));    
     }
 
     // check status

--- a/lib/passport-wsfed-saml2/strategy.js
+++ b/lib/passport-wsfed-saml2/strategy.js
@@ -114,6 +114,7 @@ WsFedSaml2Strategy.prototype._authenticate_jwt = function (req, state) {
 WsFedSaml2Strategy.prototype.authenticate = function (req, opts) {
   var self = this;
   var protocol = opts.protocol || this.options.protocol;
+
   var meta = {
     identityProviderUrl: this.options.identityProviderUrl
   };
@@ -183,7 +184,7 @@ WsFedSaml2Strategy.prototype.authenticate = function (req, opts) {
     }
   }
 
-  function executeSamlp(req) {
+  function executeSamlp(req, options) {
     if (req.body && req.method === 'POST' && req.body.SAMLResponse) {
       // We have a response, get the user identity out of it
       var loaded = function (err, ok, state) {
@@ -196,7 +197,7 @@ WsFedSaml2Strategy.prototype.authenticate = function (req, opts) {
         }
 
         var samlResponseDom = new xmldom.DOMParser().parseFromString(samlResponse);
-        self._samlp.validateSamlResponse(samlResponseDom, function (err, profile) {
+        self._samlp.validateSamlResponse(samlResponseDom, options, function (err, profile) {
           if (err) return self.fail(err, err.status || 400);
 
           var verified = function (err, user, info) {
@@ -216,6 +217,7 @@ WsFedSaml2Strategy.prototype.authenticate = function (req, opts) {
     } else {
       // Initiate new samlp authentication request
       var authzParams = self.authorizationParams(opts);
+      
       var sendRequestToIdp = function () {
         if (self.options.protocolBinding === 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST') {
           self._samlp.getSamlRequestForm(authzParams, function (err, form) {

--- a/test/fixture/samlp-server.js
+++ b/test/fixture/samlp-server.js
@@ -15,7 +15,8 @@ passport.use('samlp', new Strategy({
     path: '/callback',
     realm: 'https://auth0-dev-ed.my.salesforce.com',
     identityProviderUrl: identityProviderUrl,
-    thumbprints: ['5ca6e1202eafc0a63a5b93a43572eb2376fed309']
+    thumbprints: ['5ca6e1202eafc0a63a5b93a43572eb2376fed309'],
+    recipientUrl: 'https://auth0-dev-ed.my.salesforce.com'
   }, function(profile, done) {
     return done(null, profile);
   })
@@ -95,7 +96,8 @@ passport.use('samlp-signedresponse', new Strategy(
     path: '/callback',
     realm: 'https://auth0-dev-ed.my.salesforce.com',
     identityProviderUrl: identityProviderUrl,
-    thumbprints: ['5ca6e1202eafc0a63a5b93a43572eb2376fed309']
+    thumbprints: ['5ca6e1202eafc0a63a5b93a43572eb2376fed309'],
+    recipientUrl: 'https://auth0-dev-ed.my.salesforce.com'
   },
   function(profile, done) {
     return done(null, profile);
@@ -107,7 +109,8 @@ passport.use('samlp-signedresponse-invalidcert', new Strategy(
     path: '/callback',
     realm: 'urn:fixture-test',
     identityProviderUrl: identityProviderUrl,
-    thumbprints: ['11111111111111111a5b93a43572eb2376fed309']
+    thumbprints: ['11111111111111111a5b93a43572eb2376fed309'],
+    recipientUrl: 'https://auth0-dev-ed.my.salesforce.com'
   },
   function(profile, done) {
     return done(null, profile);
@@ -131,6 +134,7 @@ passport.use('samlp-signedresponse-signedassertion', new Strategy(
     path: '/callback',
     realm: 'urn:auth0:login-dev3',
     thumbprints: ['C9ED4DFB07CAF13FC21E0FEC1572047EB8A7A4CB'],
+    recipientUrl: 'https://login-dev3.auth0.com:3000/login/callback',
     checkExpiration: false // we are using a precomputed assertion generated from a sample idp feide
   },
   function(profile, done) {
@@ -143,6 +147,7 @@ passport.use('samlp-ping', new Strategy(
     path: '/callback',
     realm: 'urn:auth0:login-dev3',
     thumbprints: ['44340220770a348444be34970939cff8a2d74f08'],
+    recipientUrl: 'https://login-dev3.auth0.com:3000/login/callback',
     checkExpiration: false // we are using a precomputed assertion generated from a sample idp feide
   },
   function(profile, done) {
@@ -155,6 +160,7 @@ passport.use('samlp-okta', new Strategy(
     path: '/callback',
     realm: 'https://auth0145.auth0.com',
     thumbprints: ['a0c7dbb790e3476d3c5dd236f9f2060b1fd6e253'],
+    recipientUrl: 'https://auth0145.auth0.com',
     checkExpiration: false // we are using a precomputed assertion generated from a sample idp feide
   },
   function(profile, done) {
@@ -181,6 +187,7 @@ passport.use('samlp-with-utf8', new Strategy(
     path: '/callback',
     thumbprints: ['42FA24A83E107F6842E05D2A2CA0A0A0CA8A2031'],
     decryptionKey: fs.readFileSync(path.join(__dirname, '../test-decryption.key')),
+    recipientUrl: 'https://fmi-test.auth0.com/login/callback',
     checkExpiration: false, // we are using a precomputed assertion generated from a sample idp feide
     checkAudience: false
   },
@@ -253,7 +260,8 @@ module.exports.start = function(options, callback){
         issuer:             'urn:fixture-test',
         getPostURL:         getPostURL,
         cert:               credentials.cert,
-        key:                credentials.key
+        key:                credentials.key,
+        recipient:          'https://auth0-dev-ed.my.salesforce.com'
       }, module.exports.options))(req, res);
   });
 
@@ -269,7 +277,6 @@ module.exports.start = function(options, callback){
 
   app.post('/callback',
     function(req, res, next) {
-      //console.log('req.body');
       next();
     },
     passport.authenticate('samlp', { protocol: 'samlp' }),

--- a/test/interop.tests.js
+++ b/test/interop.tests.js
@@ -31,7 +31,7 @@ describe('interop', function () {
 
     var saml_passport = new SamlPassport({thumbprints: ['3464c5bdd2be7f2b6112e2f08e9c0024e33d9fe0'],
                                           realm: 'spn:408153f4-5960-43dc-9d4f-6b717d772c8d',
-                                          checkExpiration: false}); // dont check expiration since we are harcoding the token
+                                          checkExpiration: false, checkRecipient: false}); // dont check expiration since we are harcoding the token
     var profile = saml_passport.validateSamlAssertion(signedAssertion, function(err, profile) {
       if (err) return done(err);
       assert.ok(profile);
@@ -180,7 +180,8 @@ describe('interop', function () {
 
     var saml_passport = new SamlPassport({thumbprints: ['C9018666E764613366C20BC011D947B39BED236B'],
                                           realm: 'urn:auth0:auth0',
-                                          checkExpiration: false}); // dont check expiration since we are harcoding the token
+                                          checkExpiration: false,
+                                          checkRecipient: false}); // dont check expiration since we are harcoding the token
     var profile = saml_passport.validateSamlAssertion(signedAssertion, function(err, profile) {
       if (err) return done(err);
       assert.ok(profile);
@@ -194,6 +195,7 @@ describe('interop', function () {
 
     var saml_passport = new SamlPassport({thumbprints: ['42FA24A83E107F6842E05D2A2CA0A0A0CA8A2031'],
                                           realm: 'urn:auth0:fmi-test',
+                                          recipientUrl: 'https://fmi-test.auth0.com/login/callback',
                                           checkExpiration: false}); // dont check expiration since we are harcoding the token
     var profile = saml_passport.validateSamlAssertion(signedAssertion, function(err, profile) {
       if (err) return done(err);
@@ -208,6 +210,7 @@ describe('interop', function () {
     var samlOptions = {
       thumbprints: ['6BF18C1DE16D8A6C7B79A0997EF96DEEF90CBF98'],
       realm: 'urn:auth0:pwctest:SiteminderDev',
+      recipientUrl: 'https://pwctest.auth0.com/login/callback?connection=SiteminderDev',
       checkExpiration: false
     };
 
@@ -218,7 +221,8 @@ describe('interop', function () {
     var sm = new SamlPassport(samlOptions);
     var sp = new samlp(samlpOptions, sm);
 
-    sp.validateSamlResponse(new Buffer(response, 'base64').toString(), 
+    sp.validateSamlResponse(new Buffer(response, 'base64').toString(),
+      samlOptions, 
       function(err, profile){
         if (err) return done(err);
         assert.ok(profile);
@@ -233,6 +237,7 @@ describe('interop', function () {
     var samlOptions = {
       thumbprints: ['bc58b95946e0c96b464b561b02d740aeae88875a'],
       realm: 'urn:auth0:netformx:emc-test',
+      recipientUrl: 'https://fmi-test.auth0.com/login/callback',
       checkExpiration: false
     };
 
@@ -261,6 +266,7 @@ describe('interop', function () {
       cert: cert,
       thumbprints: ['bc58b95946e0c96b464b561b02d740aeae88875a'],
       realm: 'urn:auth0:netformx:emc-test',
+      recipientUrl: 'https://netformx.auth0.com/login/callback?connection=emc-test',      
       checkExpiration: false
     };
 
@@ -272,6 +278,7 @@ describe('interop', function () {
     var sp = new samlp(samlpOptions, sm);
 
     sp.validateSamlResponse(new Buffer(response, 'base64').toString(),
+      samlOptions,
       function(err, profile){
         if (err) return done(err);
         assert.ok(profile);
@@ -295,6 +302,7 @@ describe('interop', function () {
       cert: cert,
       thumbprints: ['ANOTHER_THUMB'],
       realm: 'urn:auth0:wptest:PepeSAML',
+      recipientUrl: 'https://fmi-test.auth0.com/login/callback',
       checkExpiration: false
     };
 
@@ -319,6 +327,7 @@ describe('interop', function () {
     var options = {
       thumbprint: '1756139e2a046d3c494daae6bbfa542a4367bc60',
       checkExpiration: false,
+      checkRecipient: false,
       realm: 'http://dev.pms.baxon.net/'
     };
 

--- a/test/saml11.tests.js
+++ b/test/saml11.tests.js
@@ -29,7 +29,7 @@ describe('saml 1.1 assertion', function () {
     var signedAssertion = saml11.create(options);
 
     var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
-    var saml_passport = new SamlPassport({cert: publicKey, realm: 'urn:myapp'});
+    var saml_passport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient : false});
     saml_passport.validateSamlAssertion(signedAssertion, function(error, profile) {
 
       assert.ok(profile);
@@ -62,7 +62,7 @@ describe('saml 1.1 assertion', function () {
     var signedAssertion = saml11.create(options);
 
     var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
-    var saml_passport = new SamlPassport({cert: publicKey, realm: 'urn:myapp'});
+    var saml_passport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient : false});
     var profile = saml_passport.validateSamlAssertion(signedAssertion, function(error, profile) {
       if (error) return done(error);
       
@@ -80,6 +80,7 @@ describe('saml 1.1 assertion', function () {
 
     var saml_passport = new SamlPassport({thumbprints: ['3464c5bdd2be7f2b6112e2f08e9c0024e33d9fe0'],
                                           realm: 'spn:408153f4-5960-43dc-9d4f-6b717d772c8d',
+                                          checkRecipient: false, 
                                           checkExpiration: false}); // dont check expiration since we are harcoding the token
     var profile = saml_passport.validateSamlAssertion(signedAssertion, function(error, profile) {
 
@@ -94,6 +95,7 @@ describe('saml 1.1 assertion', function () {
 
     var saml_passport = new SamlPassport({thumbprints: ['3464c5bdd2be7f2b6112e2f08e9c0024e33d9fe1', '3464c5bdd2be7f2b6112e2f08e9c0024e33d9fe2'], // WRONG thumbprints
                                           realm: 'spn:408153f4-5960-43dc-9d4f-6b717d772c8d',
+                                          checkRecipient: false,
                                           checkExpiration: false}); // dont check expiration since we are harcoding the token
     var profile = saml_passport.validateSamlAssertion(signedAssertion, function(error, profile) {
       assert.equal('Invalid thumbprint (configured: 3464C5BDD2BE7F2B6112E2F08E9C0024E33D9FE1, 3464C5BDD2BE7F2B6112E2F08E9C0024E33D9FE2. calculated: 3464C5BDD2BE7F2B6112E2F08E9C0024E33D9FE0)', error.message);

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -29,7 +29,7 @@ describe('saml 2.0 assertion', function () {
     var signedAssertion = saml20.create(options);
 
     var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
-    var saml_passport = new SamlPassport({cert: publicKey, realm: 'urn:myapp'});
+    var saml_passport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false});
     var profile = saml_passport.validateSamlAssertion(signedAssertion, function(err, profile) {
       if (err) return done(err);
 
@@ -52,7 +52,7 @@ describe('saml 2.0 assertion', function () {
 
     var signedAssertion = saml20.create(options);
     var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
-    var saml_passport = new SamlPassport({cert: publicKey, realm: 'urn:myapp'});
+    var saml_passport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false});
     var profile = saml_passport.validateSamlAssertion(signedAssertion, function(err, profile) {
       if (err) return done(err);
 
@@ -71,7 +71,24 @@ describe('saml 2.0 assertion', function () {
 
     var signedAssertion = saml20.create(options);
     var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
-    var saml_passport = new SamlPassport({cert: publicKey, realm: 'urn:myapp'});
+    var saml_passport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false});
+    var profile = saml_passport.validateSamlAssertion(signedAssertion, function(err, profile) {
+      should.exists(err);
+      err.message.should.equal('assertion has expired.');
+      should.not.exists(profile);
+      
+      done();
+    });
+
+  });
+
+   it('should validate recipent', function (done) {
+
+    options.lifetimeInSeconds = -10000;
+    options.recipient = 'foo';
+    var signedAssertion = saml20.create(options);
+    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    var saml_passport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', recipientUrl: 'foo'});
     var profile = saml_passport.validateSamlAssertion(signedAssertion, function(err, profile) {
       should.exists(err);
       err.message.should.equal('assertion has expired.');
@@ -101,7 +118,7 @@ describe('saml 2.0 assertion', function () {
     var signedAssertion = saml20.create(options);
 
     var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
-    var saml_passport = new SamlPassport({cert: publicKey, realm: 'urn:myapp'});
+    var saml_passport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false});
     var profile = saml_passport.validateSamlAssertion(signedAssertion, function(error, profile) {
       if (error) return done(error);
       
@@ -112,7 +129,5 @@ describe('saml 2.0 assertion', function () {
     });
 
   });
-
-  
 
 });

--- a/test/samlp.tests.js
+++ b/test/samlp.tests.js
@@ -621,6 +621,16 @@ describe('samlp (unit tests)', function () {
         done();
       });
     });
+
+    it('should return error for Destination does not match', function(done){
+      var samlp = new Samlp({});
+      samlp.validateSamlResponse(samlpResponseWithStatusResponderWithMessage, { checkDestination: true, recipientUrl: 'invalid' }, function (err) {
+        expect(err).to.be.ok;
+        expect(err.name).to.equals('Error');
+        expect(err.message).to.equal('Destination endpoint https://auth0-dev-ed.my.salesforce.com did not match invalid');
+        done();
+      });
+    });
   });
 
   describe('getSamlStatus', function(){
@@ -693,7 +703,6 @@ function doSamlpFlow(samlRequestUrl, callbackEndpoint, callback) {
     var $ = cheerio.load(b);
     var SAMLResponse = $('input[name="SAMLResponse"]').attr('value');
     var RelayState = $('input[name="RelayState"]').attr('value');
-
 
     request.post({
       jar: request.jar(),

--- a/test/state/samlp.state.custom.tests.js
+++ b/test/state/samlp.state.custom.tests.js
@@ -129,7 +129,7 @@ describe('samlp - using custom session state store', function() {
         return done(null, profile, { message: 'Hello' });
       });
 
-      strategy._samlp.validateSamlResponse = function(token, done) {
+      strategy._samlp.validateSamlResponse = function(token, options, done) {
         expect(token).to.be.an.object;
         done(null, { id: '1234' });
       };
@@ -250,7 +250,7 @@ describe('samlp - using custom session state store', function() {
           return done(null, profile);
         });
 
-        strategy._samlp.validateSamlResponse = function(token, done) {
+        strategy._samlp.validateSamlResponse = function(token, options, done) {
           expect(token).to.be.an.object;
           done(null, { id: '1234' });
         };
@@ -306,7 +306,7 @@ describe('samlp - using custom session state store', function() {
           return done(null, profile, { message: 'Hello' });
         });
 
-        strategy._samlp.validateSamlResponse = function(token, done) {
+        strategy._samlp.validateSamlResponse = function(token, options, done) {
           expect(token).to.be.an.object;
           done(null, { id: '1234' });
         };

--- a/test/state/samlp.state.session.tests.js
+++ b/test/state/samlp.state.session.tests.js
@@ -120,7 +120,7 @@ describe('samlp - using default session state store', function() {
         return done(null, profile, { message: 'Hello' });
       });
 
-      strategy._samlp.validateSamlResponse = function(token, done) {
+      strategy._samlp.validateSamlResponse = function(token, options, done) {
         expect(token).to.be.an.object;
         done(null, { id: '1234' });
       };
@@ -350,7 +350,7 @@ describe('samlp - using default session state store', function() {
       return done(null, profile, { message: 'Hello' });
     });
 
-    strategy._samlp.validateSamlResponse = function(token, done) {
+    strategy._samlp.validateSamlResponse = function(token, options, done) {
       expect(token).to.be.an.object;
       done(null, { id: '1234' });
     };


### PR DESCRIPTION
…so reduced the timmings

Included new flag to do Recipient validation. The check is turned on by default.

The flag checks the attributes
* Destination attribute in SAMLResponse element
* Recipient attribute in SubjectConfirmationData element (in Assertion)

Reduced clock timings to five minutes