### PR TITLE
Pass expiration validation if no restrictions are present

### DIFF
--- a/lib/passport-wsfed-saml2/saml.js
+++ b/lib/passport-wsfed-saml2/saml.js
@@ -108,7 +108,7 @@ SAML.prototype.validateSignature = function (xml, options, callback) {
 
 SAML.prototype.validateExpiration = function (samlAssertion, version) {
   var conditions = xpath.select("//*[local-name(.)='Conditions']", samlAssertion);
-  if (!conditions || conditions.length === 0) return false;
+  if (!conditions || conditions.length === 0) return true;
 
   var notBefore = new Date(conditions[0].getAttribute('NotBefore'));
   notBefore = notBefore.setMinutes(notBefore.getMinutes() - 10); // 10 minutes clock skew


### PR DESCRIPTION
If the Conditions elements is missing, the expiration validation should return `true`.
The `Conditions` element and the `NotBefore`/`NotOnOrAfter` attributes are optional, see line 822 of https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf.