### PR TITLE
Added support for token encryption on wsFed protocol

### DIFF
--- a/lib/passport-wsfed-saml2/wsfederation.js
+++ b/lib/passport-wsfed-saml2/wsfederation.js
@@ -2,6 +2,9 @@ var xmldom = require('xmldom');
 var xtend = require('xtend');
 var qs = require('querystring');
 var xpath = require('xpath');
+const fs = require("fs");
+const crypto = require("crypto");
+const ursa_purejs = require("ursa-purejs");
 
 var AuthenticationFailedError = require('./errors/AuthenticationFailedError');
 
@@ -32,16 +35,40 @@ WsFederation.prototype = {
 
   extractToken: function(req) {
     var doc = new xmldom.DOMParser().parseFromString(req.body['wresult']);
-
-    // //Probe WS-Trust 1.2 namespace (http://schemas.xmlsoap.org/ws/2005/02/trust)
+    //Probe WS-Trust 1.2 namespace (http://schemas.xmlsoap.org/ws/2005/02/trust)
     var token = doc.getElementsByTagNameNS('http://schemas.xmlsoap.org/ws/2005/02/trust', 'RequestedSecurityToken')[0];
-
-    // //Probe WS-Trust 1.3 namespace (http://docs.oasis-open.org/ws-sx/ws-trust/200512) 
+    //Probe WS-Trust 1.3 namespace (http://docs.oasis-open.org/ws-sx/ws-trust/200512) 
     if(!token){
       token = doc.getElementsByTagNameNS('http://docs.oasis-open.org/ws-sx/ws-trust/200512', 'RequestedSecurityToken')[0];
     }
-  
-    return token && token.firstChild;
+    // Is the SAML token encrypted?
+    if (!token || token.firstChild.nodeName !== 'xenc:EncryptedData') {
+        // no. return it.
+        console.log('SAML token not encrypted. return');
+        return token && token.firstChild;
+    }
+    // We need to decrypt the SAML token...
+    // Grab the CipherValue elements. There will be two:
+    //   0. The encryption key for the SAML token, encrypted by ADFS using the rsa-oaep-mgf1p 
+    //      algo and the public key of the encryption certificate configured in the relying party.
+    //   1. The SAML token, encrypted using the aes-256-cbc algo with the key from #0 ^^^
+    const ciphers = token.getElementsByTagNameNS('http://www.w3.org/2001/04/xmlenc#', 'CipherValue');
+    const aesPasswordCipher = ciphers[0].textContent;
+    const samlTokenCipher = ciphers[1].textContent;
+    // Decrypt the password for the SAML token.
+    const certPrivateKey = '../certs/token-signing.key';
+    if (!fs.existsSync(certPrivateKey)) {
+      throw new Error("The SAML token is encrypted and you haven't provided the necessary private key at the root of you project in certs/token-signing.key. Supported algo: aes-256-cbc");
+    }
+
+    const tokenSigningKey = ursa_purejs.createPrivateKey(fs.readFileSync(certPrivateKey));
+    const aesPassword = tokenSigningKey.decrypt(aesPasswordCipher, 'base64');
+    // Decrypt the SAML token.
+    const decipher = crypto.createDecipheriv('aes-256-cbc', aesPassword, crypto.randomBytes(16));
+    let saml = decipher.update(new Buffer(samlTokenCipher, 'base64'), 'binary', 'utf8');
+    saml += decipher.final('utf8');
+    // Parse the XML and return the token.
+    return new xmldom.DOMParser().parseFromString(saml).firstChild;
   },
 
   retrieveToken: function(req, callback) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jsonwebtoken": "~5.0.4",
     "passport-strategy": "^1.0.0",
     "uid2": "0.0.x",
+    "ursa-purejs": "0.0.3",
     "xml-crypto": "https://github.com/auth0/xml-crypto/tarball/064dc3464669d2ce567a01bff7a4a073420dda6d",
     "xml-encryption": "~0.8.0",
     "xml2js": "0.1.x",


### PR DESCRIPTION
Quick patch to support aes-256 encryption of SAML tokens for the wsfed protocol. Convention base for the private key: You must provide a cert at the root of you project in the certs folder named token-signing.key