### PR TITLE
Updated dependencies to fix Snyk report

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-wsfed-saml2",
-  "version": "2.11.7",
+  "version": "2.12.0",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
     "test": "mocha --reporter spec --recursive"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-wsfed-saml2",
-  "version": "2.11.6",
+  "version": "2.11.7",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
     "test": "mocha --reporter spec --recursive"
@@ -20,12 +20,12 @@
   "main": "./lib/passport-wsfed-saml2",
   "dependencies": {
     "cryptiles": "~0.2.2",
-    "ejs": "~0.8.3",
+    "ejs": "2.5.5",
     "jsonwebtoken": "~5.0.4",
     "passport-strategy": "^1.0.0",
     "uid2": "0.0.x",
     "xml-crypto": "https://github.com/auth0/xml-crypto/tarball/064dc3464669d2ce567a01bff7a4a073420dda6d",
-    "xml-encryption": "~0.8.0",
+    "xml-encryption": "0.11.0",
     "xml2js": "0.1.x",
     "xmldom": "https://github.com/auth0/xmldom/tarball/master",
     "xpath": "0.0.5",


### PR DESCRIPTION
Snyk reports potential issues with some dependencies (`ejs` and `xml-encryption`). Bumped minor version.

