### PR TITLE
Creating new patch release 3.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-wsfed-saml2",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
     "test": "mocha --reporter spec --recursive"


### PR DESCRIPTION
Bumping the version number for a patch release.

Release will contain the following updates:
* Added tests for the encoded XML value in an AttributeValue field (#74)
^ This includes an update to the xmldom dependency to fix the issue w/ pairs of encoded character entities getting dropped during XML parsing.
* Improve error message when signing certificate is invalid (#72)