### PR TITLE
Fix remaining cases where an invalid identityProviderUrl isn't handled properly

### DIFF
--- a/lib/passport-wsfed-saml2/samlp.js
+++ b/lib/passport-wsfed-saml2/samlp.js
@@ -9,6 +9,7 @@ var querystring = require('querystring');
 var SignedXml   = require('xml-crypto').SignedXml;
 var templates   = require('./templates');
 var EventEmitter = require('events');
+var validUrl     = require('valid-url');
 
 var utils                     = require('./utils');
 var AuthenticationFailedError = require('./errors/AuthenticationFailedError');
@@ -109,11 +110,16 @@ Samlp.prototype = {
   getSamlRequestParams: function (opts, callback) {
     var options = xtend(opts || {}, this.options);
 
+    var idpUrl = options.identityProviderUrl;
+    if (typeof idpUrl !== 'string' || !validUrl.isWebUri(idpUrl)) {
+      return callback(new Error(`Invalid identity provider URL: ${JSON.stringify(idpUrl)}`));
+    }
+
     var signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
     var digestAlgorithm = options.digestAlgorithm || 'sha256';
 
     var assert_and_destination = templates.assert_and_destination({
-      Destination: options.identityProviderUrl,
+      Destination: idpUrl,
       AssertionConsumerServiceURL: options.callback
     });
 
@@ -133,7 +139,7 @@ Samlp.prototype = {
     }
 
     var SAMLRequest = trimXml(!options.requestTemplate ? templates.samlrequest(model) : supplant(options.requestTemplate, model));
-    var parsedUrl = url.parse(options.identityProviderUrl, true);
+    var parsedUrl = url.parse(idpUrl, true);
     var params = {
       SAMLRequest: null,
       RelayState: options.RelayState || (parsedUrl.query && parsedUrl.query.RelayState) || ''
@@ -196,15 +202,10 @@ Samlp.prototype = {
   getSamlRequestUrl: function (opts, callback) {
     var options = xtend(opts || {}, this.options);
 
-    if (!options.identityProviderUrl) {
-      return callback(new Error('Missing value for the identity provider login URL'));
-    }
-
-    var parsedUrl = url.parse(options.identityProviderUrl, true);
-
     this.getSamlRequestParams(options, function (err, params) {
       if (err) return callback(err);
 
+      var parsedUrl = url.parse(options.identityProviderUrl, true);
       var samlRequestUrl = options.identityProviderUrl.split('?')[0] + '?' + qs.encode(xtend(parsedUrl.query, params));
       return callback(null, samlRequestUrl);
     });

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "jsonwebtoken": "~5.0.4",
     "passport-strategy": "^1.0.0",
     "uid2": "0.0.x",
+    "valid-url": "^1.0.9",
     "xml-crypto": "auth0/xml-crypto#fix-digest",
     "xml-encryption": "0.11.0",
     "xml2js": "0.1.x",


### PR DESCRIPTION
We used to parse `options.identityProviderUrl` assuming it was a string, which failed when it wasn't.

We'd fixed this in Samlp.getSamlRequestUrl(), but its siblings getSamlRequestParams() and getSamlRequestForm() were still susceptible.