### PR TITLE
3.0.11 Handle exception when signing a malformed requestTemplate

### DIFF
--- a/lib/passport-wsfed-saml2/samlp.js
+++ b/lib/passport-wsfed-saml2/samlp.js
@@ -162,7 +162,11 @@ Samlp.prototype = {
         };
 
         sig.signingKey = options.signingKey.key;
-        sig.computeSignature(SAMLRequest, { location: { reference: "//*[local-name(.)='Issuer']", action: 'after' } }); // Signature element must be located after Issuer
+        try {
+          sig.computeSignature(SAMLRequest, { location: { reference: "//*[local-name(.)='Issuer']", action: 'after' } }); // Signature element must be located after Issuer
+        } catch (e) {
+          return callback(new Error(e));
+        }
 
         SAMLRequest = trimXml(sig.getSignedXml());
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-wsfed-saml2",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
     "test": "mocha --reporter spec --recursive"

--- a/test/samlp.tests.js
+++ b/test/samlp.tests.js
@@ -7,59 +7,6 @@ var Samlp   = require('../lib/passport-wsfed-saml2/samlp');
 var Saml    = require('../lib/passport-wsfed-saml2/saml').SAML;
 
 describe('samlp (unit tests)', function () {
-  describe('samlrequest with template', function() {
-    it('should use providername option', function(done) {
-      var samlp = new Samlp({
-        identityProviderUrl: server.identityProviderUrl,
-        requestTemplate: '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="@@ID@@" IssueInstant="@@IssueInstant@@" ProviderName="@@ProviderName@@" ProtocolBinding="@@ProtocolBinding@@" Version="2.0"><saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">@@Issuer@@</saml:Issuer></samlp:AuthnRequest>',
-        protocol: 'samlp',
-        providerName: 'Some name'
-      });
-      samlp.getSamlRequestParams({}, function(err, params) {
-        expect(params).to.have.property('SAMLRequest');
-        var SAMLRequest = params.SAMLRequest;
-
-        zlib.inflateRaw(new Buffer(SAMLRequest, 'base64'), function (err, buffer) {
-          if (err) return done(err);
-
-          var request = buffer.toString();
-          var doc = new xmldom.DOMParser().parseFromString(request);
-
-          expect(doc.documentElement.getAttribute('ProviderName'))
-            .to.equal('Some name');
-
-          done();
-        });
-      });
-    });
-
-    it('should place the signature after the issuer', function(done){
-      var samlp = new Samlp({
-        identityProviderUrl: server.identityProviderUrl,
-        requestTemplate: '<samlp:AuthnRequest AssertionConsumerServiceURL="https://dev.qld-gov-dev.auth0.com/login/callback?connection=CIDM-AAL2" Destination="https://uat.identity.qld.gov.au:443/authentication/SSOPOST/metaAlias/idp-07-2017" ForceAuthn="false" ID="@@ID@@" IsPassive="false" IssueInstant="@@IssueInstant@@" ProtocolBinding="@@ProtocolBinding@@" ProviderName="@@ProviderName@@" Version="2.0" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"><saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">@@Issuer@@</saml:Issuer><samlp:RequestedAuthnContext Comparison="minimum"><saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">urn:au:qld:gov:authn:names:SAML:2.0:ac:AAL2</saml:AuthnContextClassRef><saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">urn:au:qld:gov:authn:names:SAML:2.0:attributes:FamilyName,MiddleName,GivenName,email,DateOfBirth</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>',
-        protocol: 'samlp',
-        deflate: false,
-        providerName: 'Some name',
-        signingKey: {
-          key: fs.readFileSync(__dirname + '/test-auth0.key'),
-          cert: fs.readFileSync(__dirname + '/test-auth0.pem')
-        }
-      });
-
-      samlp.getSamlRequestParams({}, function(err, params) {
-        if (err){ return done(err); }
-        expect(params).to.have.property('SAMLRequest');
-        var request = new Buffer(params.SAMLRequest, 'base64').toString()
-        var doc = new xmldom.DOMParser().parseFromString(request);
-
-        var issuer = doc.documentElement.getElementsByTagName('saml:Issuer');
-        expect(issuer[0].nextSibling.nodeName).to.equal('Signature');
-
-        done();
-      });
-    })
-  });
-
   describe('extractAssertion', function () {
 
     var samlpResponse = '<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="_0d2a510bffbb012bbc30" InResponseTo="_2N5GGp2nmITCFbcyGSKjaQ3ai6Kx9cAwDhBGX1gAJyvCrlJvoEQdjEgTsfajgM9m7j.w.I9Fz1ddVjZ9lKZChcsptp9kxkCuqcwbeNe.lJyVQpB8iSa4awFYsj9A5r7REb5JpHH72B6feguHFFPE8Mak3u4hSEKl9_8moiXLdA57WVhzwa8XYxn4mDshSp3Xb0PEZKODHMtxlVXaycGYuMgC20GpfCA" Version="2.0" IssueInstant="2014-02-25T15:20:20Z" Destination="https://auth0-dev-ed.my.salesforce.com"><saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">urn:fixture-test</saml:Issuer><samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status><saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_241siKCvX3e3oRGYtkdcV4DfGDtIsVk4" IssueInstant="2014-02-25T15:20:20.535Z"><saml:Issuer>urn:fixture-test</saml:Issuer><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">12345678</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="2014-02-25T16:20:20.535Z" InResponseTo="_2N5GGp2nmITCFbcyGSKjaQ3ai6Kx9cAwDhBGX1gAJyvCrlJvoEQdjEgTsfajgM9m7j.w.I9Fz1ddVjZ9lKZChcsptp9kxkCuqcwbeNe.lJyVQpB8iSa4awFYsj9A5r7REb5JpHH72B6feguHFFPE8Mak3u4hSEKl9_8moiXLdA57WVhzwa8XYxn4mDshSp3Xb0PEZKODHMtxlVXaycGYuMgC20GpfCA"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="2014-02-25T15:20:20.535Z" NotOnOrAfter="2014-02-25T16:20:20.535Z"><saml:AudienceRestriction><saml:Audience>https://auth0-dev-ed.my.salesforce.com</saml:Audience></saml:AudienceRestriction></saml:Conditions><saml:AttributeStatement xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"><saml:AttributeValue xsi:type="xs:anyType">12345678</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><saml:AttributeValue xsi:type="xs:anyType">jfoo@gmail.com</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"><saml:AttributeValue xsi:type="xs:anyType">John Foo</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"><saml:AttributeValue xsi:type="xs:anyType">John</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname"><saml:AttributeValue xsi:type="xs:anyType">Foo</saml:AttributeValue></saml:Attribute></saml:AttributeStatement><saml:AuthnStatement AuthnInstant="2014-02-25T15:20:20.535Z"><saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#_0d2a510bffbb012bbc30"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>YkV3DdlEa19Gb0eE3jTYTVPalV1kZ88fbIv4blO9T1Y=</DigestValue></Reference></SignedInfo><SignatureValue>ZiINpNlahQlp1JbgFsamI1/pZ+zcPsZboESVayxBMtrUBYNC4IG2VBnqku7paDxJQ7624CvcNzAYWYCv/2/c67Bv6YhQwK1rb4DPEL6OvbI8FNkYAhTNNw5UhUTEMjnJ7AncV/svUTYyIOyktuCvQh3tR4teZJV+BM3IKj9vRQQbCRNSUVHJEe963ma5HcCyo+RhIKU1pm4+ycswOlY9F115roKB4RNRJLs7Z5fyzhbOoCUujR9MMKHHq+CWaYvh5SkjaH1wMorlPlJtq5dhTZtDRhj4HwxYpCG5b4NF2vp+Jpni4dDFKou0Lzk0k6ueCJGcNHfidfEB3RB20Hed2g==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEDzCCAvegAwIBAgIJALr9HwgrQ7GeMA0GCSqGSIb3DQEBBQUAMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDAeFw0xMjEyMjkxNTMwNDdaFw0xMzAxMjgxNTMwNDdaMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMZiVmNHiXLldrgbS50ONNOH7pJ2zg6OcSMkYZGDZJbOZ/TqwauC6JOnI7+xtkPJsQHZSFJs4U0srjZKzDCmaz2jLAJDShP2jaXlrki16nDLPE//IGAg3BJguSmBCWpDbSm92V9hSsE+Mhx6bDaJiw8yQ+Q8iSm0aTQZtp6O4ICMu00ESdh9NJqIECELvP31ADV1Xhj7IbyyVPDFxMv3ol5BySE9wwwOFUq/wv7Xz9LRiUjUzPO+Lq3OM3o/uCDbk7jD7XrGUuOydALD8ULsXp4EuDO+nFbeXB/iKndZynuVKokirywl2nD2IP0/yncdLQZ8ByIyqP3G82fq/l8p7AsCAwEAAaOBxzCBxDAdBgNVHQ4EFgQUHI2rUXeBjTv1zAllaPGrHFcEK0YwgZQGA1UdIwSBjDCBiYAUHI2rUXeBjTv1zAllaPGrHFcEK0ahZqRkMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZIIJALr9HwgrQ7GeMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFrXIhCy4T4eGrikb0R2wHv/uS548r3pZyBV0CDbcRwAtbnpJMvkGFqKVp4pmyoIDSVNK/j+sLEshB20XftezHZyRJbCUbtKvXQ6FsxoeZMlN0ITYKTaoBZKhUxxj90otAhNC58qwGUPqt2LewJhHyLucKkGJ1mQ3b5xKZ532ToufouH9VLhig3H1KnxWo/zMD6Ke8cCk6qO9htuhI06s3GQGS1QWQtAmm17C6TfKgDwQFZwhqHUUZnwKRH8gU6OgZsvhgV1B7H5mjZcu57KMiDBekU9MEY0DCVTN3WkmcTII668zLsJrkNX6PEfck1AMBbVE6pEUKcWwq3uaLvlAUo=</X509Certificate></X509Data></KeyInfo></Signature></samlp:Response>';
@@ -539,6 +486,79 @@ describe('samlp (unit tests)', function () {
         expect(err).to.not.exist;
         expect(result).to.have.property('RelayState', relayState);
         done();
+      });
+    });
+
+    it('should use providername option', function(done) {
+      var samlp = new Samlp({
+        identityProviderUrl: server.identityProviderUrl,
+        requestTemplate: '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="@@ID@@" IssueInstant="@@IssueInstant@@" ProviderName="@@ProviderName@@" ProtocolBinding="@@ProtocolBinding@@" Version="2.0"><saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">@@Issuer@@</saml:Issuer></samlp:AuthnRequest>',
+        protocol: 'samlp',
+        providerName: 'Some name'
+      });
+      samlp.getSamlRequestParams({}, function(err, params) {
+        expect(params).to.have.property('SAMLRequest');
+        var SAMLRequest = params.SAMLRequest;
+
+        zlib.inflateRaw(new Buffer(SAMLRequest, 'base64'), function (err, buffer) {
+          if (err) return done(err);
+
+          var request = buffer.toString();
+          var doc = new xmldom.DOMParser().parseFromString(request);
+
+          expect(doc.documentElement.getAttribute('ProviderName'))
+            .to.equal('Some name');
+
+          done();
+        });
+      });
+    });
+
+    describe('signing', function () {
+      describe('HTTP-POST or HTTP-Redirect without deflate encoding', function () {
+        it('should error if the requestTemplate is malformed', function (done) {
+          var options = {
+            protocolBinding: 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
+            signingKey: {
+              key: fs.readFileSync(__dirname + '/test-auth0.key'),
+              cert: fs.readFileSync(__dirname + '/test-auth0.pem')
+            },
+            identityProviderUrl: 'https://example.com?RelayState=foo',
+            requestTemplate: '<samlp:AuthnRequest attribute="></samlp:AuthnRequest>'
+          };
+          this.samlp.getSamlRequestParams(options, function(err, result) {
+            expect(err).to.be.an.Error;
+            expect(err.message).to.equal('end tag name: samlp:AuthnRequest is not match the current start tagName:undefined');
+            expect(result).to.not.exist;
+            done();
+          });
+        });
+
+        it('should place the signature after the issuer', function(done){
+          var samlp = new Samlp({
+            identityProviderUrl: server.identityProviderUrl,
+            requestTemplate: '<samlp:AuthnRequest AssertionConsumerServiceURL="https://dev.qld-gov-dev.auth0.com/login/callback?connection=CIDM-AAL2" Destination="https://uat.identity.qld.gov.au:443/authentication/SSOPOST/metaAlias/idp-07-2017" ForceAuthn="false" ID="@@ID@@" IsPassive="false" IssueInstant="@@IssueInstant@@" ProtocolBinding="@@ProtocolBinding@@" ProviderName="@@ProviderName@@" Version="2.0" xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"><saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">@@Issuer@@</saml:Issuer><samlp:RequestedAuthnContext Comparison="minimum"><saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">urn:au:qld:gov:authn:names:SAML:2.0:ac:AAL2</saml:AuthnContextClassRef><saml:AuthnContextClassRef xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">urn:au:qld:gov:authn:names:SAML:2.0:attributes:FamilyName,MiddleName,GivenName,email,DateOfBirth</saml:AuthnContextClassRef></samlp:RequestedAuthnContext></samlp:AuthnRequest>',
+            protocol: 'samlp',
+            deflate: false,
+            providerName: 'Some name',
+            signingKey: {
+              key: fs.readFileSync(__dirname + '/test-auth0.key'),
+              cert: fs.readFileSync(__dirname + '/test-auth0.pem')
+            }
+          });
+
+          samlp.getSamlRequestParams({}, function(err, params) {
+            if (err){ return done(err); }
+            expect(params).to.have.property('SAMLRequest');
+            var request = new Buffer(params.SAMLRequest, 'base64').toString();
+            var doc = new xmldom.DOMParser().parseFromString(request);
+
+            var issuer = doc.documentElement.getElementsByTagName('saml:Issuer');
+            expect(issuer[0].nextSibling.nodeName).to.equal('Signature');
+
+            done();
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Also moved a couple of tests into the right `describe()`.