### PR TITLE
DF-38 Wrapping template parse to prevent uncaught

### DIFF
--- a/lib/passport-wsfed-saml2/samlp.js
+++ b/lib/passport-wsfed-saml2/samlp.js
@@ -138,7 +138,14 @@ Samlp.prototype = {
       model = xtend(model, options.requestContext);
     }
 
-    var SAMLRequest = trimXml(!options.requestTemplate ? templates.samlrequest(model) : supplant(options.requestTemplate, model));
+    var SAMLRequest;
+
+    try {
+      SAMLRequest = trimXml(!options.requestTemplate ? templates.samlrequest(model) : supplant(options.requestTemplate, model));
+    } catch (e) {
+      return callback(new Error(e));
+    }
+
     var parsedUrl = url.parse(idpUrl, true);
     var params = {
       SAMLRequest: null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-wsfed-saml2",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
     "test": "mocha --reporter spec --recursive"

--- a/test/samlp.tests.js
+++ b/test/samlp.tests.js
@@ -514,6 +514,21 @@ describe('samlp (unit tests)', function () {
       });
     });
 
+    it('should explode with invalid template', function(done) {
+      var samlp = new Samlp({
+        identityProviderUrl: server.identityProviderUrl,
+        requestTemplate: '<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" ID="@@ID@@" IssueInstant="@@IssueInstant@@" ProviderName="@@ProviderName@@" ProtocolBinding="@@ProtocolBinding@@" Version="2@@ HI THERE .0"><saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">@@Issuer@@</saml:Issuer></samlp:AuthnRequest>@@.0"><saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">@@Issuer@@</saml:Issuer></samlp:AuthnRequest>',
+        protocol: 'samlp',
+        providerName: 'Some name'
+      });
+
+      samlp.getSamlRequestParams({}, function(err, params) {
+        expect(err).not.to.be.null;
+        done();
+      });
+    });
+
+
     describe('signing', function () {
       describe('HTTP-POST or HTTP-Redirect without deflate encoding', function () {
         it('should error if the requestTemplate is malformed', function (done) {
@@ -721,3 +736,4 @@ describe('samlp (unit tests)', function () {
     });
   });
 });
+


### PR DESCRIPTION
## ✏️ Changes

There is a situation in which the @@ VAR @@ can get goofed up and
contain strings that will include part of the template itself. This will
not parse correctly and throws an exception in the replace phase of the
regex matching. I've wrapped it in a try/catch to prevent it from
bringing the process down.

Noting that this area looks problematic as it was recently patched in https://github.com/auth0/passport-wsfed-saml2/pull/88

Version bumped to `3.0.12`.

## 🔗 References

[Sentry Issue](https://sentry.io/auth0/auth0-server/issues/617753396/events/25564560312/)

## 🎯 Testing

✅ This change has unit test coverage