### PR TITLE
[DF-35] Validate issuer if pressent as an option in the strategy.

### DIFF
--- a/lib/passport-wsfed-saml2/saml.js
+++ b/lib/passport-wsfed-saml2/saml.js
@@ -355,7 +355,7 @@ SAML.prototype.parseAssertion = function(samlAssertion, callback) {
     issuer = samlAssertion.getAttribute('Issuer');
   }
 
-
+  
   this.eventEmitter.emit('parseAssertion', {
       issuer: issuer,
       version: version,
@@ -371,6 +371,10 @@ SAML.prototype.parseAssertion = function(samlAssertion, callback) {
   // Validate the SP name qualifier in the NameID element if found with the issuer
   if (self.options.checkSPNameQualifier && !self.validateSPNameQualifier(samlAssertion, self.options.realm)){
     return callback(new Error('SPNameQualifier attribute in the NameID element does not match ' + self.options.realm), null);
+  }
+
+  if (self.options.issuer && self.options.issuer !== issuer) {
+    return callback(new Error('Issuer value ' + issuer + 'does not match with the configured issuer ' + self.options.issuer), null);
   }
 
   if (!profile.email && profile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress']) {

--- a/lib/passport-wsfed-saml2/saml.js
+++ b/lib/passport-wsfed-saml2/saml.js
@@ -355,7 +355,7 @@ SAML.prototype.parseAssertion = function(samlAssertion, callback) {
     issuer = samlAssertion.getAttribute('Issuer');
   }
 
-  
+
   this.eventEmitter.emit('parseAssertion', {
       issuer: issuer,
       version: version,
@@ -374,7 +374,7 @@ SAML.prototype.parseAssertion = function(samlAssertion, callback) {
   }
 
   if (self.options.issuer && self.options.issuer !== issuer) {
-    return callback(new Error('Issuer value ' + issuer + 'does not match with the configured issuer ' + self.options.issuer), null);
+    return callback(new Error('Issuer value ' + issuer + ' does not match with the configured issuer "' + self.options.issuer + '"'), null);
   }
 
   if (!profile.email && profile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress']) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-wsfed-saml2",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
     "test": "mocha --reporter spec --recursive"

--- a/test/samlp.tests.js
+++ b/test/samlp.tests.js
@@ -392,6 +392,64 @@ describe('samlp (unit tests)', function () {
       });
     });
 
+    it('should return profile when saml response issuer is the same than the configured', function(done){
+      var encodedSamlResponse = fs.readFileSync(__dirname + '/samples/encoded/samlresponse_encrypted_and_signed.txt').toString();
+      const samlResponse = new Buffer(encodedSamlResponse, 'base64').toString();
+      var options = {
+        decryptionKey: fs.readFileSync(__dirname + '/test-auth0.key'),
+        thumbprint: '119B9E027959CDB7C662CFD075D9E2EF384E445F',
+        checkExpiration: false,
+        checkDestination: false,
+        checkRecipient: false,
+        issuer: 'http://localhost:8080/simplesaml/saml2/idp/metadata.php',
+        realm: 'urn:auth0:login0:simplephp'
+      };
+      var samlp = new Samlp(options, new Saml(options));
+      samlp.validateSamlResponse(samlResponse, function (err, profile) {
+        if (err) return done(err);
+        expect(profile).to.be.ok;
+        done();
+      });
+    });
+
+    it('should fail when saml response issuer is different than the configured one', function(done){
+      var encodedSamlResponse = fs.readFileSync(__dirname + '/samples/encoded/samlresponse_encrypted_and_signed.txt').toString();
+      const samlResponse = new Buffer(encodedSamlResponse, 'base64').toString();
+      var options = {
+        decryptionKey: fs.readFileSync(__dirname + '/test-auth0.key'),
+        thumbprint: '119B9E027959CDB7C662CFD075D9E2EF384E445F',
+        checkExpiration: false,
+        checkDestination: false,
+        checkRecipient: false,
+        issuer: 'http://localhost:8080/simplesaml/saml2/idp/metadata.php',
+        realm: 'urn:auth0:login0:simplephp'
+      };
+      var samlp = new Samlp(options, new Saml(options));
+      samlp.validateSamlResponse(samlResponse, function (err, profile) {
+        expect(err).to.be.ok;
+        done();
+      });
+    });
+
+    it('should  not fail when saml is not configured', function(done){
+      var encodedSamlResponse = fs.readFileSync(__dirname + '/samples/encoded/samlresponse_encrypted_and_signed.txt').toString();
+      const samlResponse = new Buffer(encodedSamlResponse, 'base64').toString();
+      var options = {
+        decryptionKey: fs.readFileSync(__dirname + '/test-auth0.key'),
+        thumbprint: '119B9E027959CDB7C662CFD075D9E2EF384E445F',
+        checkExpiration: false,
+        checkDestination: false,
+        checkRecipient: false,
+        issuer: 'http://localhost:8080/simplesaml/saml2/idp/metadata.php',
+        realm: 'urn:auth0:login0:simplephp'
+      };
+      var samlp = new Samlp(options, new Saml(options));
+      samlp.validateSamlResponse(samlResponse, function (err, profile) {
+        expect(err).to.be.ok;
+        done();
+      });
+    });
+
     it('should accept the signature when the saml response has an embedded XML assertion', function(done){
       var encodedSamlResponse = fs.readFileSync(__dirname + '/samples/encoded/samlresponse_encoded_xml.txt').toString();
       var cert = fs.readFileSync(__dirname + '/test-auth0-2.cer').toString();
@@ -736,4 +794,3 @@ describe('samlp (unit tests)', function () {
     });
   });
 });
-


### PR DESCRIPTION
We should be validating the SAML Assertion's issuer name as part of the core authentication pipeline.

A use case where this validation is required, is when multi-tenant SAML IdPs use the same signing certificate to sign tokens for all their tenants. In this case, signature validation alone is not sufficient and can potentially allow users of unauthorized tenants to login into the application.

A common solution is to pre-configure issuer names in the application and check the issuer-name in SAML assertion (Issuer element) in addition to the signature as part of the token validation.

I've included a new option field (`issuer`), that if present it will be compared against the issuer available in the SAML response.