### PR TITLE
DF-38 Isolating handling of malformed template

### DIFF
--- a/lib/passport-wsfed-saml2/samlp.js
+++ b/lib/passport-wsfed-saml2/samlp.js
@@ -139,12 +139,19 @@ Samlp.prototype = {
     }
 
     var SAMLRequest;
+    var rawRequest;
 
-    try {
-      SAMLRequest = trimXml(!options.requestTemplate ? templates.samlrequest(model) : supplant(options.requestTemplate, model));
-    } catch (e) {
-      return callback(new Error(e));
+    if (options.requestTemplate) {
+      try {
+        rawRequest = supplant(options.requestTemplate, model)
+      } catch (e) {
+        return callback(new Error('Malformed template passed. Could not parse.'))
+      }
+    } else {
+      rawRequest = templates.samlrequest(model);
     }
+
+    SAMLRequest = trimXml(rawRequest);
 
     var parsedUrl = url.parse(idpUrl, true);
     var params = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-wsfed-saml2",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
     "test": "mocha --reporter spec --recursive"

--- a/test/samlp.tests.js
+++ b/test/samlp.tests.js
@@ -524,6 +524,7 @@ describe('samlp (unit tests)', function () {
 
       samlp.getSamlRequestParams({}, function(err, params) {
         expect(err).not.to.be.null;
+        expect(err.message).to.match(/Malformed template/);
         done();
       });
     });


### PR DESCRIPTION
## ✏️ Changes

Relates to #90 

Isolating handling of malformed template

The `supplant` function will explode when a template is passed in this
manner, so this will return a corresponding error message when handing
the try/catch in this way.

If we add proper XML validation down the line, we can widen this out.

Version bumped to `3.0.13`.

## 🎯 Testing

✅ This change has unit test coverage