### PR TITLE
Add support of new error message format  (for OpenSSL errors) of Node.js

### DIFF
--- a/lib/passport-wsfed-saml2/saml.js
+++ b/lib/passport-wsfed-saml2/saml.js
@@ -94,7 +94,10 @@ SAML.prototype.validateSignature = function (xml, options, callback) {
       return callback(new Error('The signing certificate is invalid (' + e.message + ')'));
     }
     if (e.opensslErrorStack !== undefined) {
-      return callback(new Error('The signing certificate is invalid (' + e.opensslErrorStack.join(', ') + ')'));
+      const err = new Error(`The signing certificate is invalid (${e.opensslErrorStack.join(', ')})`);
+      err.originalError = e;
+
+      return callback(err);
     }
 
     return callback(e);

--- a/lib/passport-wsfed-saml2/saml.js
+++ b/lib/passport-wsfed-saml2/saml.js
@@ -93,6 +93,9 @@ SAML.prototype.validateSignature = function (xml, options, callback) {
     if (e.message === 'PEM_read_bio_PUBKEY failed') {
       return callback(new Error('The signing certificate is invalid (' + e.message + ')'));
     }
+    if (e.opensslErrorStack !== undefined) {
+      return callback(new Error('The signing certificate is invalid (' + e.opensslErrorStack.join(', ') + ')'));
+    }
 
     return callback(e);
   }

--- a/test/saml11.tests.js
+++ b/test/saml11.tests.js
@@ -110,10 +110,13 @@ describe('saml 1.1 assertion', function () {
       thumbprint: '119B9E027959CDB7C662CFD075D9E2EF384E445F'
     };
 
-    const saml_passport = new SamlPassport(options);
+    const saml_passport = new  SamlPassport(options);
     const profile = saml_passport.validateSamlAssertion(signedAssertion, function(err, profile) {
       should.exists(err);
-      assert.equal('The signing certificate is invalid (PEM_read_bio_PUBKEY failed)', err.message);
+
+      let oldNpmMessage  = 'The signing certificate is invalid (PEM_read_bio_PUBKEY failed)';
+      let newNpmMessage = 'The signing certificate is invalid (error:0906700D:PEM routines:PEM_ASN1_read_bio:ASN1 lib, error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error, error:0D068066:asn1 encoding routines:ASN1_CHECK_TLEN:bad object header)';
+      assert.ok(err.message === oldNpmMessage || err.message === newNpmMessage, 'Error message for invalid certificate is incorrect');
       done();
     });
   });

--- a/test/saml11.tests.js
+++ b/test/saml11.tests.js
@@ -110,13 +110,15 @@ describe('saml 1.1 assertion', function () {
       thumbprint: '119B9E027959CDB7C662CFD075D9E2EF384E445F'
     };
 
-    const saml_passport = new  SamlPassport(options);
+    const saml_passport = new SamlPassport(options);
     const profile = saml_passport.validateSamlAssertion(signedAssertion, function(err, profile) {
-      should.exists(err);
-
-      let oldNpmMessage  = 'The signing certificate is invalid (PEM_read_bio_PUBKEY failed)';
+      let oldNpmMessage = 'The signing certificate is invalid (PEM_read_bio_PUBKEY failed)';
       let newNpmMessage = 'The signing certificate is invalid (error:0906700D:PEM routines:PEM_ASN1_read_bio:ASN1 lib, error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error, error:0D068066:asn1 encoding routines:ASN1_CHECK_TLEN:bad object header)';
+
+      assert.ok(err, 'The signing certificate was unexpectedly valid');
+      assert.ok(/signing certificate is invalid/.test(err.message), 'Error message is not the default invalid message');
       assert.ok(err.message === oldNpmMessage || err.message === newNpmMessage, 'Error message for invalid certificate is incorrect');
+
       done();
     });
   });

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -192,7 +192,9 @@ describe('saml 2.0 assertion', function () {
     const saml_passport = new SamlPassport(options);
     const profile = saml_passport.validateSamlAssertion(signedAssertion, function(err, profile) {
       should.exists(err);
-      assert.equal('The signing certificate is invalid (PEM_read_bio_PUBKEY failed)', err.message);
+      let oldNpmMessage  = 'The signing certificate is invalid (PEM_read_bio_PUBKEY failed)';
+      let newNpmMessage = 'The signing certificate is invalid (error:0906700D:PEM routines:PEM_ASN1_read_bio:ASN1 lib, error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error, error:0D068066:asn1 encoding routines:ASN1_CHECK_TLEN:bad object header)';
+      assert.ok(err.message === oldNpmMessage || err.message === newNpmMessage, 'Error message for invalid certificate is incorrect');
       done();
     });
   });


### PR DESCRIPTION
fixes https://github.com/auth0/passport-wsfed-saml2/issues/75

@machuga 
Bugfix for issue `Invalid cert tests break with Node >= 8.7.0 #75`