### PR TITLE
Use crypto randombytes for uniqueness

### DIFF
--- a/lib/passport-wsfed-saml2/utils.js
+++ b/lib/passport-wsfed-saml2/utils.js
@@ -63,7 +63,7 @@ exports.getReqUrl = function(req){
 };
 
 exports.generateUniqueID = function() {
-  var uniqueID = crypto.randomBytes(10);
+  var uniqueID = crypto.randomBytes(16);
   return uniqueID.toString('hex');
 };
 

--- a/lib/passport-wsfed-saml2/utils.js
+++ b/lib/passport-wsfed-saml2/utils.js
@@ -1,4 +1,5 @@
 var xmldom = require('xmldom');
+var crypto = require('crypto');
 
 var SamlAssertionParserError = require('./errors/SamlAssertionParserError');
 var SamlResponseParserError = require('./errors/SamlResponseParserError');
@@ -62,12 +63,8 @@ exports.getReqUrl = function(req){
 };
 
 exports.generateUniqueID = function() {
-  var chars = "abcdef0123456789";
-  var uniqueID = "";
-  for (var i = 0; i < 20; i++) {
-    uniqueID += chars.substr(Math.floor((Math.random()*15)), 1);
-  }
-  return uniqueID;
+  var uniqueID = crypto.randomBytes(10);
+  return uniqueID.toString('hex');
 };
 
 exports.getEncoding = function(xml){


### PR DESCRIPTION
passport-wsfed-saml2 uses a non cryptographically secure RNG based on Math.random to generate request ID.

This PR fixes this issue. The returned id has the same properties: 20 digits long with hex alphabet.