### PR TITLE
Catch x509 exeptions on invalid certificates

### DIFF
--- a/lib/passport-wsfed-saml2/saml.js
+++ b/lib/passport-wsfed-saml2/saml.js
@@ -87,6 +87,10 @@ SAML.prototype.validateSignature = function (xml, options, callback) {
   try {
     sig.loadSignature(signature);
     valid = sig.checkSignature(xml.toString());
+
+    if (!self.extractAndValidateCertExpiration(xml, options.cert) && self.options.checkCertExpiration) {
+      return callback(new Error('The signing certificate is not currently valid.'), null);
+    }
   } catch (e) {
     if (e.message === 'PEM_read_bio_PUBKEY failed') {
       return callback(new Error('The signing certificate is invalid (' + e.message + ')'));
@@ -99,10 +103,6 @@ SAML.prototype.validateSignature = function (xml, options, callback) {
     }
 
     return callback(e);
-  }
-
-  if (!self.extractAndValidateCertExpiration(xml, options.cert) && self.options.checkCertExpiration) {
-    return callback(new Error('The signing certificate is not currently valid.'), null);
   }
 
   if (!valid) {


### PR DESCRIPTION
If the certificate is invalid, x509 throws an exception which is not being handled properly