### PR TITLE
[Node 10] Update x509

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .DS_Store
 .vscode
+package-lock.json
+*.log

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
-before_install: npm i -g npm@1.4.28
 node_js:
   - 6
   - 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 before_install: npm i -g npm@1.4.28
 node_js:
   - 6
+  - 8
+  - 10

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "passport-strategy": "^1.0.0",
     "uid2": "0.0.x",
     "valid-url": "^1.0.9",
-    "x509": "auth0/node-x509#v0.3.3-auth0",
+    "x509": "^0.3.4",
     "xml-crypto": "auth0/xml-crypto#fix-digest",
     "xml-encryption": "0.11.0",
     "xml2js": "0.1.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-wsfed-saml2",
-  "version": "3.0.17",
+  "version": "4.0.0",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
     "test": "mocha --reporter spec --recursive"

--- a/test/saml11.tests.js
+++ b/test/saml11.tests.js
@@ -111,13 +111,16 @@ describe('saml 1.1 assertion', function () {
     };
 
     const saml_passport = new SamlPassport(options);
-    const profile = saml_passport.validateSamlAssertion(signedAssertion, function(err, profile) {
-      let oldNpmMessage = 'The signing certificate is invalid (PEM_read_bio_PUBKEY failed)';
-      let newNpmMessage = 'The signing certificate is invalid (error:0906700D:PEM routines:PEM_ASN1_read_bio:ASN1 lib, error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error, error:0D068066:asn1 encoding routines:ASN1_CHECK_TLEN:bad object header)';
+    saml_passport.validateSamlAssertion(signedAssertion, function(err, profile) {
+    const errorMessages = [
+        'The signing certificate is invalid (PEM_read_bio_PUBKEY failed)',
+        'The signing certificate is invalid (error:0906700D:PEM routines:PEM_ASN1_read_bio:ASN1 lib, error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error, error:0D068066:asn1 encoding routines:ASN1_CHECK_TLEN:bad object header)',
+        'The signing certificate is invalid (error:0D07803A:asn1 encoding routines:asn1_item_embed_d2i:nested asn1 error, error:0D068066:asn1 encoding routines:asn1_check_tlen:bad object header)'
+      ];
 
       assert.ok(err, 'The signing certificate was unexpectedly valid');
       assert.ok(/signing certificate is invalid/.test(err.message), 'Error message is not the default invalid message');
-      assert.ok(err.message === oldNpmMessage || err.message === newNpmMessage, 'Error message for invalid certificate is incorrect');
+      assert.ok(errorMessages.includes(err.message), 'Error message for invalid certificate is incorrect');
 
       done();
     });

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -264,11 +264,16 @@ describe('saml 2.0 assertion', function () {
     };
 
     const samlPassport = new SamlPassport(options);
-    const profile = samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
+    samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
       should.exists(err);
-      let oldNpmMessage  = 'The signing certificate is invalid (PEM_read_bio_PUBKEY failed)';
-      let newNpmMessage = 'The signing certificate is invalid (error:0906700D:PEM routines:PEM_ASN1_read_bio:ASN1 lib, error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error, error:0D068066:asn1 encoding routines:ASN1_CHECK_TLEN:bad object header)';
-      assert.ok(err.message === oldNpmMessage || err.message === newNpmMessage, 'Error message for invalid certificate is incorrect');
+      const errorMessages = [
+        'The signing certificate is invalid (PEM_read_bio_PUBKEY failed)',
+        'The signing certificate is invalid (error:0906700D:PEM routines:PEM_ASN1_read_bio:ASN1 lib, error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error, error:0D068066:asn1 encoding routines:ASN1_CHECK_TLEN:bad object header)',
+        'The signing certificate is invalid (error:0D07803A:asn1 encoding routines:asn1_item_embed_d2i:nested asn1 error, error:0D068066:asn1 encoding routines:asn1_check_tlen:bad object header)'
+      ];
+
+      assert.ok(err, 'The signing certificate was unexpectedly valid');
+      assert.ok(errorMessages.includes(err.message), 'Error message for invalid certificate is incorrect');
       done();
     });
   });


### PR DESCRIPTION
Update x509 to support Node 10 and use the original repo - not the fork since it's published correctly as of 0.3.4 and the memory leak was fixed as of 0.3.2.