### PR TITLE
[build] Move CI away from Travis and to Github Actions

### DIFF
--- a/.github/ci.yml
+++ b/.github/ci.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Test execution
+      run: npm run cover

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .vscode
 package-lock.json
 *.log
+coverage/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - 6
-  - 8
-  - 10

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Passport-wsfed-saml2
 =============
 
-[![Build Status](https://travis-ci.org/auth0/passport-wsfed-saml2.png)](https://travis-ci.org/auth0/passport-wsfed-saml2)
+![Build Status](https://github.com/auth0/passport-wsfed-saml2/workflows/Tests/badge.svg)
 
 This is a ws-federation protocol + SAML2 tokens authentication provider for [Passport](http://passportjs.org/).
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "4.3.0",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
-    "test": "mocha --reporter spec --recursive"
+    "test": "./node_modules/.bin/_mocha -R spec --colors",
+    "cover": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- -R spec --colors"
   },
   "author": {
     "name": "Matias Woloski",
@@ -37,6 +38,7 @@
     "chai-passport-strategy": "1.x.x",
     "cheerio": "~0.19.0",
     "express": "~3.11.0",
+    "istanbul": "^0.4.5",
     "mocha": "~1.8.1",
     "passport": "^0.3.2",
     "request": "~2.88.0",


### PR DESCRIPTION
### Description

Travis CI was being super slow. This moves CI to Github actions along with the following changes:

- Run tests in Node 10, 12, 14, 15. (The currently supported versions only. https://nodejs.org/en/about/releases/ )
- Add coverage report

### References

N/A

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
