### PR TITLE
add Destination & AssertionConsumerServiceURL as SAML req template vars

### DIFF
--- a/lib/passport-wsfed-saml2/samlp.js
+++ b/lib/passport-wsfed-saml2/samlp.js
@@ -148,6 +148,8 @@ Samlp.prototype = {
       Issuer:           options.realm,
       ProtocolBinding:  options.protocolBinding || BINDINGS.HTTP_POST,
       ForceAuthn:       options.forceAuthn,
+      Destination:      idpUrl,
+      AssertionConsumerServiceURL: options.callback,
       AssertServiceURLAndDestination: assert_and_destination,
       AuthnContext:     options.authnContext || '',
       ProviderName:     options.providerName || ''

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-wsfed-saml2",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
     "test": "./node_modules/.bin/_mocha -R spec --colors",


### PR DESCRIPTION
### Description

Adding support for these two SAML request template variables so tenants can control these assertions on a per-connection basis.
- Destination
- AssertionConsumerServiceURL

### References

https://auth0team.atlassian.net/browse/ULP-2795

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
