### PR TITLE
Allow options.assertionConsumerServiceURL or options.callback

### DIFF
--- a/lib/passport-wsfed-saml2/samlp.js
+++ b/lib/passport-wsfed-saml2/samlp.js
@@ -149,7 +149,7 @@ Samlp.prototype = {
       ProtocolBinding:  options.protocolBinding || BINDINGS.HTTP_POST,
       ForceAuthn:       options.forceAuthn,
       Destination:      idpUrl,
-      AssertionConsumerServiceURL: options.callback,
+      AssertionConsumerServiceURL: options.assertionConsumerServiceURL || options.callback,
       AssertServiceURLAndDestination: assert_and_destination,
       AuthnContext:     options.authnContext || '',
       ProviderName:     options.providerName || ''

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-wsfed-saml2",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
     "test": "./node_modules/.bin/_mocha -R spec --colors",


### PR DESCRIPTION
### Description

Allow AssertionConsumerServiceURL to be provided by `options.callback` OR `options.assertionConsumerServiceURL`.


### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
