### PR TITLE
Drop node 10, update/consolidate dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -23,4 +23,4 @@ jobs:
       run: npm install
 
     - name: Test execution
-      run: npm run cover
+      run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 .DS_Store
-.vscode
 package-lock.json
 *.log
-coverage/*
+coverage
+.nyc_output

--- a/.npmignore
+++ b/.npmignore
@@ -8,5 +8,6 @@ examples/
 support/
 test/
 coverage/
+.nyc_output/
 node_modules/
 package-lock.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach Mocha Debug",
+      "type": "node",
+      "request": "attach",
+      "port": 8217,
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "4.5.1",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
-    "test": "./node_modules/.bin/_mocha -R spec --colors",
-    "cover": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- -R spec --colors"
+    "test": "./node_modules/.bin/mocha --recursive",
+    "test-debug": "./node_modules/.bin/mocha --recursive --inspect-brk=8217",
+    "cover": "nyc npm run test"
   },
   "author": {
     "name": "Matias Woloski",
@@ -20,6 +21,7 @@
   },
   "main": "./lib/passport-wsfed-saml2",
   "dependencies": {
+    "@auth0/xmldom": "0.1.22",
     "ejs": "2.5.5",
     "jsonwebtoken": "~5.0.4",
     "node-forge": "^0.10.0",
@@ -28,27 +30,24 @@
     "valid-url": "^1.0.9",
     "xml-crypto": "auth0/xml-crypto#v1.4.1-auth0.2",
     "xml-encryption": "^1.2.1",
-    "xml2js": "0.1.x",
-    "@auth0/xmldom": "0.1.22",
     "xpath": "0.0.5",
     "xtend": "~2.0.3"
   },
   "devDependencies": {
-    "chai": "2.x.x",
+    "chai": "~4.3.4",
     "chai-passport-strategy": "1.x.x",
-    "cheerio": "~0.19.0",
+    "cheerio": "~1.0.0-rc.10",
     "express": "~3.11.0",
-    "istanbul": "^0.4.5",
-    "mocha": "~1.8.1",
-    "passport": "^0.3.2",
+    "mocha": "~9.0.2",
+    "nyc": "~15.1.0",
+    "passport": "^0.4.1",
     "request": "~2.88.0",
     "saml": "~0.4.4",
     "samlp": "~0.4.3",
-    "should": "~1.1.0",
     "wsfed": "~0.3.5"
   },
   "engines": {
-    "node": ">= 10"
+    "node": ">= 12"
   },
   "licenses": [
     {

--- a/test/saml11.tests.js
+++ b/test/saml11.tests.js
@@ -1,7 +1,6 @@
 var assert = require('assert'),
     fs = require('fs'),
     helpers = require('./helpers'),
-    should = require('should'),
     saml11 = require('saml').Saml11,
     SamlPassport = require('../lib/passport-wsfed-saml2/saml').SAML;
 

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -1,16 +1,15 @@
-var assert = require('assert'),
-    fs = require('fs'),
-    helpers = require('./helpers'),
-    should = require('should'),
-    saml20 = require('saml').Saml20,
-    utils = require('../lib/passport-wsfed-saml2/utils'),
-    SamlPassport = require('../lib/passport-wsfed-saml2/saml').SAML;
+const assert = require('assert');
+const fs = require('fs');
+const { expect } = require('chai');
+const saml20 = require('saml').Saml20;
+const utils = require('../lib/passport-wsfed-saml2/utils');
+const SamlPassport = require('../lib/passport-wsfed-saml2/saml').SAML;
 
 describe('saml 2.0 assertion', function () {
   // cert created with:
   // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
 
-  var options = {
+  const options = {
     cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
     key: fs.readFileSync(__dirname + '/test-auth0.key'),
     issuer: 'urn:issuer',
@@ -26,11 +25,11 @@ describe('saml 2.0 assertion', function () {
 
   it('should parse attributes', function (done) {
 
-    var signedAssertion = saml20.create(options);
+    const signedAssertion = saml20.create(options);
 
-    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
     const samlPassport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false});
-    var profile = samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
+    samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
       if (err) return done(err);
 
       assert.ok(profile);
@@ -44,11 +43,11 @@ describe('saml 2.0 assertion', function () {
   });
 
   it('should ignore the NameQualifier validation when nameid format is "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"', function (done) {
-    var signedAssertion = '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_ne0Z8R1z9xdbekXeWrAAg7srNB78exsb" IssueInstant="2016-08-02T21:54:04.971Z"><saml:Issuer>urn:issuer</saml:Issuer><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#_ne0Z8R1z9xdbekXeWrAAg7srNB78exsb"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>p7iHnIt5xJZNimGNxh4d9R2J7DML8WNrMwMxmZ1WwSU=</DigestValue></Reference></SignedInfo><SignatureValue>pb1Wp/LFbigEj+TNm7gkAwlfIc17LNwUXVTgM8RQnMvYJfIPZbl1yo5xMCh6ObMFwCs1T+gKI5C7jMloX2QhWD/XUffBKiDfkZUg7NI/Jyt5m+Bdst12SNhHBVsNilL9ZCuf+QtQD7301gUhVHP6Ramf4y+XNod9AfzhFLYNfl6fhf/5KA/KkjiOwYW5Ps/43OMXXSeVaeQ7JRU8XqyKbwlB+YXGseFLnyZopv8Cw9Bb2935ADLX111oFBkiRhnMUJW0LMbSWM6UVJ4V0qoW9h+f3isN5+R87RECNeAQP3WSBiddnEuSdhgQYQVnb6s0mThpvs7uvIOlog0FqeSrvQ==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEDzCCAvegAwIBAgIJALr9HwgrQ7GeMA0GCSqGSIb3DQEBBQUAMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDAeFw0xMjEyMjkxNTMwNDdaFw0xMzAxMjgxNTMwNDdaMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMZiVmNHiXLldrgbS50ONNOH7pJ2zg6OcSMkYZGDZJbOZ/TqwauC6JOnI7+xtkPJsQHZSFJs4U0srjZKzDCmaz2jLAJDShP2jaXlrki16nDLPE//IGAg3BJguSmBCWpDbSm92V9hSsE+Mhx6bDaJiw8yQ+Q8iSm0aTQZtp6O4ICMu00ESdh9NJqIECELvP31ADV1Xhj7IbyyVPDFxMv3ol5BySE9wwwOFUq/wv7Xz9LRiUjUzPO+Lq3OM3o/uCDbk7jD7XrGUuOydALD8ULsXp4EuDO+nFbeXB/iKndZynuVKokirywl2nD2IP0/yncdLQZ8ByIyqP3G82fq/l8p7AsCAwEAAaOBxzCBxDAdBgNVHQ4EFgQUHI2rUXeBjTv1zAllaPGrHFcEK0YwgZQGA1UdIwSBjDCBiYAUHI2rUXeBjTv1zAllaPGrHFcEK0ahZqRkMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZIIJALr9HwgrQ7GeMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFrXIhCy4T4eGrikb0R2wHv/uS548r3pZyBV0CDbcRwAtbnpJMvkGFqKVp4pmyoIDSVNK/j+sLEshB20XftezHZyRJbCUbtKvXQ6FsxoeZMlN0ITYKTaoBZKhUxxj90otAhNC58qwGUPqt2LewJhHyLucKkGJ1mQ3b5xKZ532ToufouH9VLhig3H1KnxWo/zMD6Ke8cCk6qO9htuhI06s3GQGS1QWQtAmm17C6TfKgDwQFZwhqHUUZnwKRH8gU6OgZsvhgV1B7H5mjZcu57KMiDBekU9MEY0DCVTN3WkmcTII668zLsJrkNX6PEfck1AMBbVE6pEUKcWwq3uaLvlAUo=</X509Certificate></X509Data></KeyInfo></Signature><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" NameQualifier="name-qualifier">foo</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="2016-08-02T22:04:04.971Z"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="2016-08-02T21:54:04.971Z" NotOnOrAfter="2016-08-02T22:04:04.971Z"><saml:AudienceRestriction><saml:Audience>urn:myapp</saml:Audience></saml:AudienceRestriction></saml:Conditions><saml:AttributeStatement xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><saml:AttributeValue xsi:type="xs:anyType">foo@bar.com</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"><saml:AttributeValue xsi:type="xs:anyType">Foo Bar</saml:AttributeValue></saml:Attribute></saml:AttributeStatement><saml:AuthnStatement AuthnInstant="2016-08-02T21:54:04.971Z"><saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion>';
+    const signedAssertion = '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_ne0Z8R1z9xdbekXeWrAAg7srNB78exsb" IssueInstant="2016-08-02T21:54:04.971Z"><saml:Issuer>urn:issuer</saml:Issuer><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#_ne0Z8R1z9xdbekXeWrAAg7srNB78exsb"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>p7iHnIt5xJZNimGNxh4d9R2J7DML8WNrMwMxmZ1WwSU=</DigestValue></Reference></SignedInfo><SignatureValue>pb1Wp/LFbigEj+TNm7gkAwlfIc17LNwUXVTgM8RQnMvYJfIPZbl1yo5xMCh6ObMFwCs1T+gKI5C7jMloX2QhWD/XUffBKiDfkZUg7NI/Jyt5m+Bdst12SNhHBVsNilL9ZCuf+QtQD7301gUhVHP6Ramf4y+XNod9AfzhFLYNfl6fhf/5KA/KkjiOwYW5Ps/43OMXXSeVaeQ7JRU8XqyKbwlB+YXGseFLnyZopv8Cw9Bb2935ADLX111oFBkiRhnMUJW0LMbSWM6UVJ4V0qoW9h+f3isN5+R87RECNeAQP3WSBiddnEuSdhgQYQVnb6s0mThpvs7uvIOlog0FqeSrvQ==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEDzCCAvegAwIBAgIJALr9HwgrQ7GeMA0GCSqGSIb3DQEBBQUAMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDAeFw0xMjEyMjkxNTMwNDdaFw0xMzAxMjgxNTMwNDdaMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMZiVmNHiXLldrgbS50ONNOH7pJ2zg6OcSMkYZGDZJbOZ/TqwauC6JOnI7+xtkPJsQHZSFJs4U0srjZKzDCmaz2jLAJDShP2jaXlrki16nDLPE//IGAg3BJguSmBCWpDbSm92V9hSsE+Mhx6bDaJiw8yQ+Q8iSm0aTQZtp6O4ICMu00ESdh9NJqIECELvP31ADV1Xhj7IbyyVPDFxMv3ol5BySE9wwwOFUq/wv7Xz9LRiUjUzPO+Lq3OM3o/uCDbk7jD7XrGUuOydALD8ULsXp4EuDO+nFbeXB/iKndZynuVKokirywl2nD2IP0/yncdLQZ8ByIyqP3G82fq/l8p7AsCAwEAAaOBxzCBxDAdBgNVHQ4EFgQUHI2rUXeBjTv1zAllaPGrHFcEK0YwgZQGA1UdIwSBjDCBiYAUHI2rUXeBjTv1zAllaPGrHFcEK0ahZqRkMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZIIJALr9HwgrQ7GeMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFrXIhCy4T4eGrikb0R2wHv/uS548r3pZyBV0CDbcRwAtbnpJMvkGFqKVp4pmyoIDSVNK/j+sLEshB20XftezHZyRJbCUbtKvXQ6FsxoeZMlN0ITYKTaoBZKhUxxj90otAhNC58qwGUPqt2LewJhHyLucKkGJ1mQ3b5xKZ532ToufouH9VLhig3H1KnxWo/zMD6Ke8cCk6qO9htuhI06s3GQGS1QWQtAmm17C6TfKgDwQFZwhqHUUZnwKRH8gU6OgZsvhgV1B7H5mjZcu57KMiDBekU9MEY0DCVTN3WkmcTII668zLsJrkNX6PEfck1AMBbVE6pEUKcWwq3uaLvlAUo=</X509Certificate></X509Data></KeyInfo></Signature><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" NameQualifier="name-qualifier">foo</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="2016-08-02T22:04:04.971Z"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="2016-08-02T21:54:04.971Z" NotOnOrAfter="2016-08-02T22:04:04.971Z"><saml:AudienceRestriction><saml:Audience>urn:myapp</saml:Audience></saml:AudienceRestriction></saml:Conditions><saml:AttributeStatement xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><saml:AttributeValue xsi:type="xs:anyType">foo@bar.com</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"><saml:AttributeValue xsi:type="xs:anyType">Foo Bar</saml:AttributeValue></saml:Attribute></saml:AttributeStatement><saml:AuthnStatement AuthnInstant="2016-08-02T21:54:04.971Z"><saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion>';
 
-    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
     const samlPassport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false, checkExpiration: false});
-    var profile = samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
+    samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
       if (err) return done(err);
 
       assert.ok(profile);
@@ -62,11 +61,11 @@ describe('saml 2.0 assertion', function () {
   });
 
   it('should ignore the SPNameQualifier validation when the nameid format is "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"', function (done) {
-    var signedAssertion = '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_nPmKm9IskDCo61hUea4DX7o3POLbLcUK" IssueInstant="2016-08-02T21:59:48.654Z"><saml:Issuer>urn:issuer</saml:Issuer><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#_nPmKm9IskDCo61hUea4DX7o3POLbLcUK"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>UYsy9NacnRqnSTbidM8WBBgS+Op0G05iBJTX0T1WlUk=</DigestValue></Reference></SignedInfo><SignatureValue>VzRQaMR5Qk1P+g1tqJRKroq4JJx00FZ0rZxO4vG2gGkBXJ8262B4VUHOkxyPHNH1l/DuxSnNsL8AAbZfn8EdxMdToPvm2hkqygyA5W20o6g6eSC41rDOavTzesOKoXn3Uq9DOiUXve5ieYYCt5bQcoSCVT6uhVEKMhdcLhaB507qj9Gzcfp0E4F57ezRTTnVVEF/wCJ5j0QTMA2Wh09fxNkGijlE8KHzDJZapN4tDCzmK8qY7211gKuTfKYJGXYA4hSxw9fiQGDEPKRYA6tWf0HO5Vd8edRg2ZHr7AgjuCPp5Fj8VOP+KppA1YFBbq4Eqqt6KHg91KJlGs3ivpmwPw==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEDzCCAvegAwIBAgIJALr9HwgrQ7GeMA0GCSqGSIb3DQEBBQUAMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDAeFw0xMjEyMjkxNTMwNDdaFw0xMzAxMjgxNTMwNDdaMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMZiVmNHiXLldrgbS50ONNOH7pJ2zg6OcSMkYZGDZJbOZ/TqwauC6JOnI7+xtkPJsQHZSFJs4U0srjZKzDCmaz2jLAJDShP2jaXlrki16nDLPE//IGAg3BJguSmBCWpDbSm92V9hSsE+Mhx6bDaJiw8yQ+Q8iSm0aTQZtp6O4ICMu00ESdh9NJqIECELvP31ADV1Xhj7IbyyVPDFxMv3ol5BySE9wwwOFUq/wv7Xz9LRiUjUzPO+Lq3OM3o/uCDbk7jD7XrGUuOydALD8ULsXp4EuDO+nFbeXB/iKndZynuVKokirywl2nD2IP0/yncdLQZ8ByIyqP3G82fq/l8p7AsCAwEAAaOBxzCBxDAdBgNVHQ4EFgQUHI2rUXeBjTv1zAllaPGrHFcEK0YwgZQGA1UdIwSBjDCBiYAUHI2rUXeBjTv1zAllaPGrHFcEK0ahZqRkMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZIIJALr9HwgrQ7GeMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFrXIhCy4T4eGrikb0R2wHv/uS548r3pZyBV0CDbcRwAtbnpJMvkGFqKVp4pmyoIDSVNK/j+sLEshB20XftezHZyRJbCUbtKvXQ6FsxoeZMlN0ITYKTaoBZKhUxxj90otAhNC58qwGUPqt2LewJhHyLucKkGJ1mQ3b5xKZ532ToufouH9VLhig3H1KnxWo/zMD6Ke8cCk6qO9htuhI06s3GQGS1QWQtAmm17C6TfKgDwQFZwhqHUUZnwKRH8gU6OgZsvhgV1B7H5mjZcu57KMiDBekU9MEY0DCVTN3WkmcTII668zLsJrkNX6PEfck1AMBbVE6pEUKcWwq3uaLvlAUo=</X509Certificate></X509Data></KeyInfo></Signature><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" SPNameQualifier="other-qualifier">foo</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="2016-08-02T22:09:48.654Z"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="2016-08-02T21:59:48.654Z" NotOnOrAfter="2016-08-02T22:09:48.654Z"><saml:AudienceRestriction><saml:Audience>urn:myapp</saml:Audience></saml:AudienceRestriction></saml:Conditions><saml:AttributeStatement xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><saml:AttributeValue xsi:type="xs:anyType">foo@bar.com</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"><saml:AttributeValue xsi:type="xs:anyType">Foo Bar</saml:AttributeValue></saml:Attribute></saml:AttributeStatement><saml:AuthnStatement AuthnInstant="2016-08-02T21:59:48.654Z"><saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion>';
+    const signedAssertion = '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_nPmKm9IskDCo61hUea4DX7o3POLbLcUK" IssueInstant="2016-08-02T21:59:48.654Z"><saml:Issuer>urn:issuer</saml:Issuer><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#_nPmKm9IskDCo61hUea4DX7o3POLbLcUK"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>UYsy9NacnRqnSTbidM8WBBgS+Op0G05iBJTX0T1WlUk=</DigestValue></Reference></SignedInfo><SignatureValue>VzRQaMR5Qk1P+g1tqJRKroq4JJx00FZ0rZxO4vG2gGkBXJ8262B4VUHOkxyPHNH1l/DuxSnNsL8AAbZfn8EdxMdToPvm2hkqygyA5W20o6g6eSC41rDOavTzesOKoXn3Uq9DOiUXve5ieYYCt5bQcoSCVT6uhVEKMhdcLhaB507qj9Gzcfp0E4F57ezRTTnVVEF/wCJ5j0QTMA2Wh09fxNkGijlE8KHzDJZapN4tDCzmK8qY7211gKuTfKYJGXYA4hSxw9fiQGDEPKRYA6tWf0HO5Vd8edRg2ZHr7AgjuCPp5Fj8VOP+KppA1YFBbq4Eqqt6KHg91KJlGs3ivpmwPw==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEDzCCAvegAwIBAgIJALr9HwgrQ7GeMA0GCSqGSIb3DQEBBQUAMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDAeFw0xMjEyMjkxNTMwNDdaFw0xMzAxMjgxNTMwNDdaMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMZiVmNHiXLldrgbS50ONNOH7pJ2zg6OcSMkYZGDZJbOZ/TqwauC6JOnI7+xtkPJsQHZSFJs4U0srjZKzDCmaz2jLAJDShP2jaXlrki16nDLPE//IGAg3BJguSmBCWpDbSm92V9hSsE+Mhx6bDaJiw8yQ+Q8iSm0aTQZtp6O4ICMu00ESdh9NJqIECELvP31ADV1Xhj7IbyyVPDFxMv3ol5BySE9wwwOFUq/wv7Xz9LRiUjUzPO+Lq3OM3o/uCDbk7jD7XrGUuOydALD8ULsXp4EuDO+nFbeXB/iKndZynuVKokirywl2nD2IP0/yncdLQZ8ByIyqP3G82fq/l8p7AsCAwEAAaOBxzCBxDAdBgNVHQ4EFgQUHI2rUXeBjTv1zAllaPGrHFcEK0YwgZQGA1UdIwSBjDCBiYAUHI2rUXeBjTv1zAllaPGrHFcEK0ahZqRkMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZIIJALr9HwgrQ7GeMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFrXIhCy4T4eGrikb0R2wHv/uS548r3pZyBV0CDbcRwAtbnpJMvkGFqKVp4pmyoIDSVNK/j+sLEshB20XftezHZyRJbCUbtKvXQ6FsxoeZMlN0ITYKTaoBZKhUxxj90otAhNC58qwGUPqt2LewJhHyLucKkGJ1mQ3b5xKZ532ToufouH9VLhig3H1KnxWo/zMD6Ke8cCk6qO9htuhI06s3GQGS1QWQtAmm17C6TfKgDwQFZwhqHUUZnwKRH8gU6OgZsvhgV1B7H5mjZcu57KMiDBekU9MEY0DCVTN3WkmcTII668zLsJrkNX6PEfck1AMBbVE6pEUKcWwq3uaLvlAUo=</X509Certificate></X509Data></KeyInfo></Signature><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified" SPNameQualifier="other-qualifier">foo</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="2016-08-02T22:09:48.654Z"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="2016-08-02T21:59:48.654Z" NotOnOrAfter="2016-08-02T22:09:48.654Z"><saml:AudienceRestriction><saml:Audience>urn:myapp</saml:Audience></saml:AudienceRestriction></saml:Conditions><saml:AttributeStatement xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><saml:AttributeValue xsi:type="xs:anyType">foo@bar.com</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"><saml:AttributeValue xsi:type="xs:anyType">Foo Bar</saml:AttributeValue></saml:Attribute></saml:AttributeStatement><saml:AuthnStatement AuthnInstant="2016-08-02T21:59:48.654Z"><saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion>';
 
-    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
     const samlPassport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false, checkExpiration: false});
-    var profile = samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
+    samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
       if (err) return done(err);
 
       assert.ok(profile);
@@ -80,22 +79,22 @@ describe('saml 2.0 assertion', function () {
   });
 
    it('should validate the NameQualifier when nameid format is "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"', function (done) {
-    var signedAssertion = '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_dZZwXmRpwYcaIdFA5l0qSCCuu0if9UNo" IssueInstant="2016-09-29T12:34:13.488Z"><saml:Issuer>urn:issuer</saml:Issuer><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#_dZZwXmRpwYcaIdFA5l0qSCCuu0if9UNo"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>ndqj65JwACeDERG2aZF6k0IF85KshkhgILzxhbKRyiw=</DigestValue></Reference></SignedInfo><SignatureValue>LPcIU9W9HmX1QM+baMPLTj9StBFRksnDoFn/HVd8uLJgdH8Xeiv9TOQGElmSaBLypjCeN6ILq6pcZ0mxMC9zfd9X3WKmYtcrGI1BugATeNsqUm63x+Msau8pNuZrNNbfIQvLooMhF4T92ym2ADSm+zCQVNwBH7/v0rVIE6MEy8AYqqfpvH9CR88XQYMCSgKN0JQ2FPbcHvhIX7Hl+xG6PSzgfznE8dcWBUi24FajyGpqlNm8O3uHCfjR3wzO42UQIJFOJOiLb7QGNyWE1KXKYWyzZgAxGQuRUcbYxcnKTbVK3b3TBH+p2ZR+a2ktKmvqNBvQxy6tE4UXDIIpvmknSw==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEDzCCAvegAwIBAgIJALr9HwgrQ7GeMA0GCSqGSIb3DQEBBQUAMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDAeFw0xMjEyMjkxNTMwNDdaFw0xMzAxMjgxNTMwNDdaMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMZiVmNHiXLldrgbS50ONNOH7pJ2zg6OcSMkYZGDZJbOZ/TqwauC6JOnI7+xtkPJsQHZSFJs4U0srjZKzDCmaz2jLAJDShP2jaXlrki16nDLPE//IGAg3BJguSmBCWpDbSm92V9hSsE+Mhx6bDaJiw8yQ+Q8iSm0aTQZtp6O4ICMu00ESdh9NJqIECELvP31ADV1Xhj7IbyyVPDFxMv3ol5BySE9wwwOFUq/wv7Xz9LRiUjUzPO+Lq3OM3o/uCDbk7jD7XrGUuOydALD8ULsXp4EuDO+nFbeXB/iKndZynuVKokirywl2nD2IP0/yncdLQZ8ByIyqP3G82fq/l8p7AsCAwEAAaOBxzCBxDAdBgNVHQ4EFgQUHI2rUXeBjTv1zAllaPGrHFcEK0YwgZQGA1UdIwSBjDCBiYAUHI2rUXeBjTv1zAllaPGrHFcEK0ahZqRkMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZIIJALr9HwgrQ7GeMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFrXIhCy4T4eGrikb0R2wHv/uS548r3pZyBV0CDbcRwAtbnpJMvkGFqKVp4pmyoIDSVNK/j+sLEshB20XftezHZyRJbCUbtKvXQ6FsxoeZMlN0ITYKTaoBZKhUxxj90otAhNC58qwGUPqt2LewJhHyLucKkGJ1mQ3b5xKZ532ToufouH9VLhig3H1KnxWo/zMD6Ke8cCk6qO9htuhI06s3GQGS1QWQtAmm17C6TfKgDwQFZwhqHUUZnwKRH8gU6OgZsvhgV1B7H5mjZcu57KMiDBekU9MEY0DCVTN3WkmcTII668zLsJrkNX6PEfck1AMBbVE6pEUKcWwq3uaLvlAUo=</X509Certificate></X509Data></KeyInfo></Signature><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" NameQualifier="invalid-value">foo</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="2016-09-29T12:44:13.488Z"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="2016-09-29T12:34:13.488Z" NotOnOrAfter="2016-09-29T12:44:13.488Z"><saml:AudienceRestriction><saml:Audience>urn:myapp</saml:Audience></saml:AudienceRestriction></saml:Conditions><saml:AttributeStatement xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><saml:AttributeValue xsi:type="xs:anyType">foo@bar.com</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"><saml:AttributeValue xsi:type="xs:anyType">Foo Bar</saml:AttributeValue></saml:Attribute></saml:AttributeStatement><saml:AuthnStatement AuthnInstant="2016-09-29T12:34:13.488Z"><saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion>';
+    const signedAssertion = '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_dZZwXmRpwYcaIdFA5l0qSCCuu0if9UNo" IssueInstant="2016-09-29T12:34:13.488Z"><saml:Issuer>urn:issuer</saml:Issuer><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#_dZZwXmRpwYcaIdFA5l0qSCCuu0if9UNo"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>ndqj65JwACeDERG2aZF6k0IF85KshkhgILzxhbKRyiw=</DigestValue></Reference></SignedInfo><SignatureValue>LPcIU9W9HmX1QM+baMPLTj9StBFRksnDoFn/HVd8uLJgdH8Xeiv9TOQGElmSaBLypjCeN6ILq6pcZ0mxMC9zfd9X3WKmYtcrGI1BugATeNsqUm63x+Msau8pNuZrNNbfIQvLooMhF4T92ym2ADSm+zCQVNwBH7/v0rVIE6MEy8AYqqfpvH9CR88XQYMCSgKN0JQ2FPbcHvhIX7Hl+xG6PSzgfznE8dcWBUi24FajyGpqlNm8O3uHCfjR3wzO42UQIJFOJOiLb7QGNyWE1KXKYWyzZgAxGQuRUcbYxcnKTbVK3b3TBH+p2ZR+a2ktKmvqNBvQxy6tE4UXDIIpvmknSw==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEDzCCAvegAwIBAgIJALr9HwgrQ7GeMA0GCSqGSIb3DQEBBQUAMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDAeFw0xMjEyMjkxNTMwNDdaFw0xMzAxMjgxNTMwNDdaMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMZiVmNHiXLldrgbS50ONNOH7pJ2zg6OcSMkYZGDZJbOZ/TqwauC6JOnI7+xtkPJsQHZSFJs4U0srjZKzDCmaz2jLAJDShP2jaXlrki16nDLPE//IGAg3BJguSmBCWpDbSm92V9hSsE+Mhx6bDaJiw8yQ+Q8iSm0aTQZtp6O4ICMu00ESdh9NJqIECELvP31ADV1Xhj7IbyyVPDFxMv3ol5BySE9wwwOFUq/wv7Xz9LRiUjUzPO+Lq3OM3o/uCDbk7jD7XrGUuOydALD8ULsXp4EuDO+nFbeXB/iKndZynuVKokirywl2nD2IP0/yncdLQZ8ByIyqP3G82fq/l8p7AsCAwEAAaOBxzCBxDAdBgNVHQ4EFgQUHI2rUXeBjTv1zAllaPGrHFcEK0YwgZQGA1UdIwSBjDCBiYAUHI2rUXeBjTv1zAllaPGrHFcEK0ahZqRkMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZIIJALr9HwgrQ7GeMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFrXIhCy4T4eGrikb0R2wHv/uS548r3pZyBV0CDbcRwAtbnpJMvkGFqKVp4pmyoIDSVNK/j+sLEshB20XftezHZyRJbCUbtKvXQ6FsxoeZMlN0ITYKTaoBZKhUxxj90otAhNC58qwGUPqt2LewJhHyLucKkGJ1mQ3b5xKZ532ToufouH9VLhig3H1KnxWo/zMD6Ke8cCk6qO9htuhI06s3GQGS1QWQtAmm17C6TfKgDwQFZwhqHUUZnwKRH8gU6OgZsvhgV1B7H5mjZcu57KMiDBekU9MEY0DCVTN3WkmcTII668zLsJrkNX6PEfck1AMBbVE6pEUKcWwq3uaLvlAUo=</X509Certificate></X509Data></KeyInfo></Signature><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" NameQualifier="invalid-value">foo</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="2016-09-29T12:44:13.488Z"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="2016-09-29T12:34:13.488Z" NotOnOrAfter="2016-09-29T12:44:13.488Z"><saml:AudienceRestriction><saml:Audience>urn:myapp</saml:Audience></saml:AudienceRestriction></saml:Conditions><saml:AttributeStatement xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><saml:AttributeValue xsi:type="xs:anyType">foo@bar.com</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"><saml:AttributeValue xsi:type="xs:anyType">Foo Bar</saml:AttributeValue></saml:Attribute></saml:AttributeStatement><saml:AuthnStatement AuthnInstant="2016-09-29T12:34:13.488Z"><saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion>';
 
-    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
     const samlPassport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false, checkExpiration: false});
-    var profile = samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
+    samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
       assert.equal(err.message, 'NameQualifier attribute in the NameID element does not match urn:issuer');
       done();
     });
   });
 
   it('should validate the SPNameQualifier when the nameid format is "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"', function (done) {
-    var signedAssertion = '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_muhd3ZBmN9LK3Ev08rkc8CA40YvNOkGl" IssueInstant="2016-09-29T12:35:22.345Z"><saml:Issuer>urn:issuer</saml:Issuer><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#_muhd3ZBmN9LK3Ev08rkc8CA40YvNOkGl"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>Gsh2DubHXYDeuHyBa+DU1k5G43UjyQsyPRYVgEqpTD8=</DigestValue></Reference></SignedInfo><SignatureValue>mubsqLCaM16gT2rAFLl8XDuLWTALH6cdRMM/kNHLpVzO5PA6FGVPX5ojW2UCKGOhGHn0Hd/mYCOCtgAROphWjxpQl5TDyeQE0frjKs8ik0V/Jjy5T6PeWKHLqN6sHbP6YpkGixshCWtop8JOs6SijM9PBGnWal6Nx5bUMBfAyUnGyIhLwNaE8Z4NHkyAqmdxgLS0e8w5qngKQaUlyERZCrqKQ4w8VaHFG4Dos36XVfh+U7udo3IlbrpBLsu9xG1Azxe2iPC6+84xC09P6EvQylvTnz5NU4jhk10SmmRjZ6AVvzJTz/gbVfRfZoEAUhCuIIh3HuRwf400ESf38ouZTA==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEDzCCAvegAwIBAgIJALr9HwgrQ7GeMA0GCSqGSIb3DQEBBQUAMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDAeFw0xMjEyMjkxNTMwNDdaFw0xMzAxMjgxNTMwNDdaMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMZiVmNHiXLldrgbS50ONNOH7pJ2zg6OcSMkYZGDZJbOZ/TqwauC6JOnI7+xtkPJsQHZSFJs4U0srjZKzDCmaz2jLAJDShP2jaXlrki16nDLPE//IGAg3BJguSmBCWpDbSm92V9hSsE+Mhx6bDaJiw8yQ+Q8iSm0aTQZtp6O4ICMu00ESdh9NJqIECELvP31ADV1Xhj7IbyyVPDFxMv3ol5BySE9wwwOFUq/wv7Xz9LRiUjUzPO+Lq3OM3o/uCDbk7jD7XrGUuOydALD8ULsXp4EuDO+nFbeXB/iKndZynuVKokirywl2nD2IP0/yncdLQZ8ByIyqP3G82fq/l8p7AsCAwEAAaOBxzCBxDAdBgNVHQ4EFgQUHI2rUXeBjTv1zAllaPGrHFcEK0YwgZQGA1UdIwSBjDCBiYAUHI2rUXeBjTv1zAllaPGrHFcEK0ahZqRkMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZIIJALr9HwgrQ7GeMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFrXIhCy4T4eGrikb0R2wHv/uS548r3pZyBV0CDbcRwAtbnpJMvkGFqKVp4pmyoIDSVNK/j+sLEshB20XftezHZyRJbCUbtKvXQ6FsxoeZMlN0ITYKTaoBZKhUxxj90otAhNC58qwGUPqt2LewJhHyLucKkGJ1mQ3b5xKZ532ToufouH9VLhig3H1KnxWo/zMD6Ke8cCk6qO9htuhI06s3GQGS1QWQtAmm17C6TfKgDwQFZwhqHUUZnwKRH8gU6OgZsvhgV1B7H5mjZcu57KMiDBekU9MEY0DCVTN3WkmcTII668zLsJrkNX6PEfck1AMBbVE6pEUKcWwq3uaLvlAUo=</X509Certificate></X509Data></KeyInfo></Signature><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" SPNameQualifier="invalid-value">foo</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="2016-09-29T12:45:22.345Z"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="2016-09-29T12:35:22.345Z" NotOnOrAfter="2016-09-29T12:45:22.345Z"><saml:AudienceRestriction><saml:Audience>urn:myapp</saml:Audience></saml:AudienceRestriction></saml:Conditions><saml:AttributeStatement xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><saml:AttributeValue xsi:type="xs:anyType">foo@bar.com</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"><saml:AttributeValue xsi:type="xs:anyType">Foo Bar</saml:AttributeValue></saml:Attribute></saml:AttributeStatement><saml:AuthnStatement AuthnInstant="2016-09-29T12:35:22.345Z"><saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion>';
+    const signedAssertion = '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_muhd3ZBmN9LK3Ev08rkc8CA40YvNOkGl" IssueInstant="2016-09-29T12:35:22.345Z"><saml:Issuer>urn:issuer</saml:Issuer><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#_muhd3ZBmN9LK3Ev08rkc8CA40YvNOkGl"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>Gsh2DubHXYDeuHyBa+DU1k5G43UjyQsyPRYVgEqpTD8=</DigestValue></Reference></SignedInfo><SignatureValue>mubsqLCaM16gT2rAFLl8XDuLWTALH6cdRMM/kNHLpVzO5PA6FGVPX5ojW2UCKGOhGHn0Hd/mYCOCtgAROphWjxpQl5TDyeQE0frjKs8ik0V/Jjy5T6PeWKHLqN6sHbP6YpkGixshCWtop8JOs6SijM9PBGnWal6Nx5bUMBfAyUnGyIhLwNaE8Z4NHkyAqmdxgLS0e8w5qngKQaUlyERZCrqKQ4w8VaHFG4Dos36XVfh+U7udo3IlbrpBLsu9xG1Azxe2iPC6+84xC09P6EvQylvTnz5NU4jhk10SmmRjZ6AVvzJTz/gbVfRfZoEAUhCuIIh3HuRwf400ESf38ouZTA==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEDzCCAvegAwIBAgIJALr9HwgrQ7GeMA0GCSqGSIb3DQEBBQUAMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDAeFw0xMjEyMjkxNTMwNDdaFw0xMzAxMjgxNTMwNDdaMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMZiVmNHiXLldrgbS50ONNOH7pJ2zg6OcSMkYZGDZJbOZ/TqwauC6JOnI7+xtkPJsQHZSFJs4U0srjZKzDCmaz2jLAJDShP2jaXlrki16nDLPE//IGAg3BJguSmBCWpDbSm92V9hSsE+Mhx6bDaJiw8yQ+Q8iSm0aTQZtp6O4ICMu00ESdh9NJqIECELvP31ADV1Xhj7IbyyVPDFxMv3ol5BySE9wwwOFUq/wv7Xz9LRiUjUzPO+Lq3OM3o/uCDbk7jD7XrGUuOydALD8ULsXp4EuDO+nFbeXB/iKndZynuVKokirywl2nD2IP0/yncdLQZ8ByIyqP3G82fq/l8p7AsCAwEAAaOBxzCBxDAdBgNVHQ4EFgQUHI2rUXeBjTv1zAllaPGrHFcEK0YwgZQGA1UdIwSBjDCBiYAUHI2rUXeBjTv1zAllaPGrHFcEK0ahZqRkMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZIIJALr9HwgrQ7GeMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFrXIhCy4T4eGrikb0R2wHv/uS548r3pZyBV0CDbcRwAtbnpJMvkGFqKVp4pmyoIDSVNK/j+sLEshB20XftezHZyRJbCUbtKvXQ6FsxoeZMlN0ITYKTaoBZKhUxxj90otAhNC58qwGUPqt2LewJhHyLucKkGJ1mQ3b5xKZ532ToufouH9VLhig3H1KnxWo/zMD6Ke8cCk6qO9htuhI06s3GQGS1QWQtAmm17C6TfKgDwQFZwhqHUUZnwKRH8gU6OgZsvhgV1B7H5mjZcu57KMiDBekU9MEY0DCVTN3WkmcTII668zLsJrkNX6PEfck1AMBbVE6pEUKcWwq3uaLvlAUo=</X509Certificate></X509Data></KeyInfo></Signature><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" SPNameQualifier="invalid-value">foo</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="2016-09-29T12:45:22.345Z"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="2016-09-29T12:35:22.345Z" NotOnOrAfter="2016-09-29T12:45:22.345Z"><saml:AudienceRestriction><saml:Audience>urn:myapp</saml:Audience></saml:AudienceRestriction></saml:Conditions><saml:AttributeStatement xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><saml:AttributeValue xsi:type="xs:anyType">foo@bar.com</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"><saml:AttributeValue xsi:type="xs:anyType">Foo Bar</saml:AttributeValue></saml:Attribute></saml:AttributeStatement><saml:AuthnStatement AuthnInstant="2016-09-29T12:35:22.345Z"><saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion>';
 
-    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
     const samlPassport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false, checkExpiration: false});
-    var profile = samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
+    samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
       assert.equal(err.message, 'SPNameQualifier attribute in the NameID element does not match urn:myapp');
       done();
     });
@@ -107,52 +106,47 @@ describe('saml 2.0 assertion', function () {
       'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/groups': ['Admins', 'Contributors']
     };
 
-    var signedAssertion = saml20.create(options);
-    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    const signedAssertion = saml20.create(options);
+    const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
     const samlPassport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false});
-    var profile = samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
+    samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
       if (err) return done(err);
 
-      assert.ok(profile);
-      profile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/groups'].should.be.an.instanceOf(Array);
-      profile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/groups'].should.include('Admins');
-      profile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/groups'].should.include('Contributors');
+      expect(profile).to.exist;
+      expect(profile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/groups']).to.be.an('array');
+      expect(profile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/groups']).to.include('Admins');
+      expect(profile['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/groups']).to.include('Contributors');
       done();
     });
-
   });
 
   it('should validate expiration with default clockSkew', function (done) {
 
     options.lifetimeInSeconds = -240;
 
-    var signedAssertion = saml20.create(options);
-    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    const signedAssertion = saml20.create(options);
+    const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
     const samlPassport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false});
-    var profile = samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
-      should.exists(err);
-      err.message.should.equal('assertion has expired.');
-      should.not.exists(profile);
-
+    samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
+      expect(err).to.exist;
+      expect(err.message).to.equal('assertion has expired.');
+      expect(profile).to.not.exist;
       done();
     });
-
   });
 
   it('should validate expiration with overriden clockSkew', function (done) {
 
     options.lifetimeInSeconds = -240;
 
-    var signedAssertion = saml20.create(options);
-    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    const signedAssertion = saml20.create(options);
+    const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
     const samlPassport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false, clockSkew: 5});
-    var profile = samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
-      should.not.exists(err);
-      should.exists(profile);
-
+    samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
+      expect(err).to.not.exist;
+      expect(profile).to.exist;
       done();
     });
-
   });
 
 
@@ -160,40 +154,35 @@ describe('saml 2.0 assertion', function () {
 
     options.lifetimeInSeconds = 10000;
 
-    var signedAssertion = saml20.create(options);
-    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    const signedAssertion = saml20.create(options);
+    const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
     // The embedded cert is expired, so we can use this as is.
     const samlPassport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false});
     samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
-      should.not.exists(err);
-      should.exists(profile);
+      expect(err).to.not.exist;
+      expect(profile).to.exist;
       done();
     });
-
   });
 
   it('should validate certificate expiration with embedded cert', function (done) {
-
-    var signedAssertion = saml20.create(options);
-    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    const signedAssertion = saml20.create(options);
+    const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
     // The embedded cert is expired, so we can use this as is.
     const samlPassport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false, checkCertExpiration: true});
     samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
-      should.exists(err);
-      err.message.should.equal('The signing certificate is not currently valid.');
-      should.not.exists(profile);
-
+      expect(err).to.exist;
+      expect(err.message).to.equal('The signing certificate is not currently valid.');
+      expect(profile).to.be.undefined;
       done();
     });
-
   });
 
 
   it('should validate certificate expiration with non-embedded cert', function (done) {
+    const signedAssertion = saml20.create(options);
 
-    var signedAssertion = saml20.create(options);
-
-    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
     // The test cert is expired, so we can use this as is.
     const samlPassport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false, checkCertExpiration: true});
     const parsedAssertion = utils.parseSamlAssertion(signedAssertion);
@@ -203,32 +192,29 @@ describe('saml 2.0 assertion', function () {
     assert.equal(parsedAssertion.getElementsByTagName("X509Certificate").length, 0); // Make sure we removed the cert(s)
 
     samlPassport.validateSamlAssertion(parsedAssertion, function(err, profile) {
-      should.exists(err);
-      err.message.should.equal('The signing certificate is not currently valid.');
-      should.not.exists(profile);
-
+      expect(err).to.exist;
+      expect(err.message).to.equal('The signing certificate is not currently valid.');
+      expect(profile).to.not.exist;
       done();
     });
-
   });
 
   it('should validate recipent', function (done) {
     options.lifetimeInSeconds = 600;
     options.recipient = 'foo';
-    var signedAssertion = saml20.create(options);
-    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    const signedAssertion = saml20.create(options);
+    const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
     const samlPassport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', recipientUrl: 'bar'});
-    var profile = samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
-      should.exists(err);
-      err.message.should.equal('Recipient is invalid. Configured: bar');
-      should.not.exists(profile);
+    samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
+      expect(err).to.exist;
+      expect(err.message).to.equal('Recipient is invalid. Configured: bar');
+      expect(profile).to.not.exist;
       done();
     });
   });
 
   it('should extract authentication context from assertion as a user prop', function (done) {
-
-    var options = {
+    const options = {
       cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
       key: fs.readFileSync(__dirname + '/test-auth0.key'),
       issuer: 'urn:issuer',
@@ -242,11 +228,11 @@ describe('saml 2.0 assertion', function () {
       nameIdentifierFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
     };
 
-    var signedAssertion = saml20.create(options);
+    const signedAssertion = saml20.create(options);
 
-    var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+    const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
     const samlPassport = new SamlPassport({cert: publicKey, realm: 'urn:myapp', checkRecipient: false});
-    var profile = samlPassport.validateSamlAssertion(signedAssertion, function(error, profile) {
+    samlPassport.validateSamlAssertion(signedAssertion, function(error, profile) {
       if (error) return done(error);
 
       assert.ok(profile);
@@ -265,7 +251,7 @@ describe('saml 2.0 assertion', function () {
 
     const samlPassport = new SamlPassport(options);
     samlPassport.validateSamlAssertion(signedAssertion, function(err, profile) {
-      should.exists(err);
+      expect(err).to.exist;
       const errorMessages = [
         'The signing certificate is invalid (PEM_read_bio_PUBKEY failed)',
         'The signing certificate is invalid (error:0906700D:PEM routines:PEM_ASN1_read_bio:ASN1 lib, error:0D07803A:asn1 encoding routines:ASN1_ITEM_EX_D2I:nested asn1 error, error:0D068066:asn1 encoding routines:ASN1_CHECK_TLEN:bad object header)',
@@ -282,9 +268,9 @@ describe('saml 2.0 assertion', function () {
     it('should fail when signature is not found', function (done) {
       const assertion = '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_muhd3ZBmN9LK3Ev08rkc8CA40YvNOkGl" IssueInstant="2016-09-29T12:35:22.345Z"><saml:Issuer>urn:issuer</saml:Issuer><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" SPNameQualifier="invalid-value">foo</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="2016-09-29T12:45:22.345Z"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="2016-09-29T12:35:22.345Z" NotOnOrAfter="2016-09-29T12:45:22.345Z"><saml:AudienceRestriction><saml:Audience>urn:myapp</saml:Audience></saml:AudienceRestriction></saml:Conditions><saml:AttributeStatement xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><saml:AttributeValue xsi:type="xs:anyType">foo@bar.com</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"><saml:AttributeValue xsi:type="xs:anyType">Foo Bar</saml:AttributeValue></saml:Attribute></saml:AttributeStatement><saml:AuthnStatement AuthnInstant="2016-09-29T12:35:22.345Z"><saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement></saml:Assertion>';
 
-      var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+      const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
       const samlPassport = new SamlPassport({ cert: publicKey, realm: 'urn:myapp', checkRecipient: false });
-      var profile = samlPassport.validateSamlAssertion(assertion, function (err, profile) {
+      samlPassport.validateSamlAssertion(assertion, function (err, profile) {
         assert.ok(err);
         assert.ok(!profile);
         assert.equal(err.message, "Signature is missing (xpath: /*[local-name(.)='Assertion']/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#'])");
@@ -295,9 +281,9 @@ describe('saml 2.0 assertion', function () {
     it('should fail when signature is found twice', function (done) {
       const assertion = '<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" ID="_muhd3ZBmN9LK3Ev08rkc8CA40YvNOkGl" IssueInstant="2016-09-29T12:35:22.345Z"><saml:Issuer>urn:issuer</saml:Issuer><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#_muhd3ZBmN9LK3Ev08rkc8CA40YvNOkGl"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>Gsh2DubHXYDeuHyBa+DU1k5G43UjyQsyPRYVgEqpTD8=</DigestValue></Reference></SignedInfo><SignatureValue>mubsqLCaM16gT2rAFLl8XDuLWTALH6cdRMM/kNHLpVzO5PA6FGVPX5ojW2UCKGOhGHn0Hd/mYCOCtgAROphWjxpQl5TDyeQE0frjKs8ik0V/Jjy5T6PeWKHLqN6sHbP6YpkGixshCWtop8JOs6SijM9PBGnWal6Nx5bUMBfAyUnGyIhLwNaE8Z4NHkyAqmdxgLS0e8w5qngKQaUlyERZCrqKQ4w8VaHFG4Dos36XVfh+U7udo3IlbrpBLsu9xG1Azxe2iPC6+84xC09P6EvQylvTnz5NU4jhk10SmmRjZ6AVvzJTz/gbVfRfZoEAUhCuIIh3HuRwf400ESf38ouZTA==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEDzCCAvegAwIBAgIJALr9HwgrQ7GeMA0GCSqGSIb3DQEBBQUAMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDAeFw0xMjEyMjkxNTMwNDdaFw0xMzAxMjgxNTMwNDdaMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMZiVmNHiXLldrgbS50ONNOH7pJ2zg6OcSMkYZGDZJbOZ/TqwauC6JOnI7+xtkPJsQHZSFJs4U0srjZKzDCmaz2jLAJDShP2jaXlrki16nDLPE//IGAg3BJguSmBCWpDbSm92V9hSsE+Mhx6bDaJiw8yQ+Q8iSm0aTQZtp6O4ICMu00ESdh9NJqIECELvP31ADV1Xhj7IbyyVPDFxMv3ol5BySE9wwwOFUq/wv7Xz9LRiUjUzPO+Lq3OM3o/uCDbk7jD7XrGUuOydALD8ULsXp4EuDO+nFbeXB/iKndZynuVKokirywl2nD2IP0/yncdLQZ8ByIyqP3G82fq/l8p7AsCAwEAAaOBxzCBxDAdBgNVHQ4EFgQUHI2rUXeBjTv1zAllaPGrHFcEK0YwgZQGA1UdIwSBjDCBiYAUHI2rUXeBjTv1zAllaPGrHFcEK0ahZqRkMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZIIJALr9HwgrQ7GeMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFrXIhCy4T4eGrikb0R2wHv/uS548r3pZyBV0CDbcRwAtbnpJMvkGFqKVp4pmyoIDSVNK/j+sLEshB20XftezHZyRJbCUbtKvXQ6FsxoeZMlN0ITYKTaoBZKhUxxj90otAhNC58qwGUPqt2LewJhHyLucKkGJ1mQ3b5xKZ532ToufouH9VLhig3H1KnxWo/zMD6Ke8cCk6qO9htuhI06s3GQGS1QWQtAmm17C6TfKgDwQFZwhqHUUZnwKRH8gU6OgZsvhgV1B7H5mjZcu57KMiDBekU9MEY0DCVTN3WkmcTII668zLsJrkNX6PEfck1AMBbVE6pEUKcWwq3uaLvlAUo=</X509Certificate></X509Data></KeyInfo></Signature><saml:Subject><saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent" SPNameQualifier="invalid-value">foo</saml:NameID><saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"><saml:SubjectConfirmationData NotOnOrAfter="2016-09-29T12:45:22.345Z"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore="2016-09-29T12:35:22.345Z" NotOnOrAfter="2016-09-29T12:45:22.345Z"><saml:AudienceRestriction><saml:Audience>urn:myapp</saml:Audience></saml:AudienceRestriction></saml:Conditions><saml:AttributeStatement xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"><saml:AttributeValue xsi:type="xs:anyType">foo@bar.com</saml:AttributeValue></saml:Attribute><saml:Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"><saml:AttributeValue xsi:type="xs:anyType">Foo Bar</saml:AttributeValue></saml:Attribute></saml:AttributeStatement><saml:AuthnStatement AuthnInstant="2016-09-29T12:35:22.345Z"><saml:AuthnContext><saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef></saml:AuthnContext></saml:AuthnStatement><Signature xmlns="http://www.w3.org/2000/09/xmldsig#"><SignedInfo><CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><Reference URI="#_muhd3ZBmN9LK3Ev08rkc8CA40YvNOkGl"><Transforms><Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></Transforms><DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><DigestValue>Gsh2DubHXYDeuHyBa+DU1k5G43UjyQsyPRYVgEqpTD8=</DigestValue></Reference></SignedInfo><SignatureValue>mubsqLCaM16gT2rAFLl8XDuLWTALH6cdRMM/kNHLpVzO5PA6FGVPX5ojW2UCKGOhGHn0Hd/mYCOCtgAROphWjxpQl5TDyeQE0frjKs8ik0V/Jjy5T6PeWKHLqN6sHbP6YpkGixshCWtop8JOs6SijM9PBGnWal6Nx5bUMBfAyUnGyIhLwNaE8Z4NHkyAqmdxgLS0e8w5qngKQaUlyERZCrqKQ4w8VaHFG4Dos36XVfh+U7udo3IlbrpBLsu9xG1Azxe2iPC6+84xC09P6EvQylvTnz5NU4jhk10SmmRjZ6AVvzJTz/gbVfRfZoEAUhCuIIh3HuRwf400ESf38ouZTA==</SignatureValue><KeyInfo><X509Data><X509Certificate>MIIEDzCCAvegAwIBAgIJALr9HwgrQ7GeMA0GCSqGSIb3DQEBBQUAMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDAeFw0xMjEyMjkxNTMwNDdaFw0xMzAxMjgxNTMwNDdaMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMZiVmNHiXLldrgbS50ONNOH7pJ2zg6OcSMkYZGDZJbOZ/TqwauC6JOnI7+xtkPJsQHZSFJs4U0srjZKzDCmaz2jLAJDShP2jaXlrki16nDLPE//IGAg3BJguSmBCWpDbSm92V9hSsE+Mhx6bDaJiw8yQ+Q8iSm0aTQZtp6O4ICMu00ESdh9NJqIECELvP31ADV1Xhj7IbyyVPDFxMv3ol5BySE9wwwOFUq/wv7Xz9LRiUjUzPO+Lq3OM3o/uCDbk7jD7XrGUuOydALD8ULsXp4EuDO+nFbeXB/iKndZynuVKokirywl2nD2IP0/yncdLQZ8ByIyqP3G82fq/l8p7AsCAwEAAaOBxzCBxDAdBgNVHQ4EFgQUHI2rUXeBjTv1zAllaPGrHFcEK0YwgZQGA1UdIwSBjDCBiYAUHI2rUXeBjTv1zAllaPGrHFcEK0ahZqRkMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZIIJALr9HwgrQ7GeMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFrXIhCy4T4eGrikb0R2wHv/uS548r3pZyBV0CDbcRwAtbnpJMvkGFqKVp4pmyoIDSVNK/j+sLEshB20XftezHZyRJbCUbtKvXQ6FsxoeZMlN0ITYKTaoBZKhUxxj90otAhNC58qwGUPqt2LewJhHyLucKkGJ1mQ3b5xKZ532ToufouH9VLhig3H1KnxWo/zMD6Ke8cCk6qO9htuhI06s3GQGS1QWQtAmm17C6TfKgDwQFZwhqHUUZnwKRH8gU6OgZsvhgV1B7H5mjZcu57KMiDBekU9MEY0DCVTN3WkmcTII668zLsJrkNX6PEfck1AMBbVE6pEUKcWwq3uaLvlAUo=</X509Certificate></X509Data></KeyInfo></Signature></saml:Assertion>';
 
-      var publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
+      const publicKey = fs.readFileSync(__dirname + '/test-auth0.cer').toString();
       const samlPassport = new SamlPassport({ cert: publicKey, realm: 'urn:myapp', checkRecipient: false });
-      var profile = samlPassport.validateSamlAssertion(assertion, function (err, profile) {
+      samlPassport.validateSamlAssertion(assertion, function (err, profile) {
         assert.ok(err);
         assert.ok(!profile);
         assert.equal(err.message, "Signature was found more than one time (xpath: /*[local-name(.)='Assertion']/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#'])");
@@ -305,5 +291,4 @@ describe('saml 2.0 assertion', function () {
       });
     });
   });
-
 });

--- a/test/samlp.tests.js
+++ b/test/samlp.tests.js
@@ -515,7 +515,7 @@ describe('samlp (unit tests)', function () {
     it('should error if the identityProviderUrl is not a string', function(done) {
       var options = {identityProviderUrl: 42};
       this.samlp.getSamlRequestParams(options, function(err, result) {
-        expect(err).to.be.an.Error;
+        expect(err).to.be.an('error');
         expect(err.message).to.equal('Invalid identity provider URL: 42');
         expect(result).to.not.exist;
         done();
@@ -525,7 +525,7 @@ describe('samlp (unit tests)', function () {
     it('should error if the identityProviderUrl is a string but not a URL', function(done) {
       var options = {identityProviderUrl: 'not a URL'};
       this.samlp.getSamlRequestParams(options, function(err, result) {
-        expect(err).to.be.an.Error;
+        expect(err).to.be.an('error');
         expect(err.message).to.equal('Invalid identity provider URL: "not a URL"');
         expect(result).to.not.exist;
         done();
@@ -596,7 +596,7 @@ describe('samlp (unit tests)', function () {
             requestTemplate: '<samlp:AuthnRequest attribute="></samlp:AuthnRequest>'
           };
           this.samlp.getSamlRequestParams(options, function(err, result) {
-            expect(err).to.be.an.Error;
+            expect(err).to.be.an('error');
             expect(err.message).to.equal('fail to compute signature');
             expect(result).to.not.exist;
             done();
@@ -647,7 +647,7 @@ describe('samlp (unit tests)', function () {
     it('should error if the identityProviderUrl is not a URL', function(done) {
       var options = {identityProviderUrl: null};
       this.samlp.getSamlRequestUrl(options, function(err, result) {
-        expect(err).to.be.an.Error;
+        expect(err).to.be.an('error');
         expect(err.message).to.equal('Invalid identity provider URL: null');
         expect(result).to.not.exist;
         done();

--- a/test/state/samlp.state.custom.tests.js
+++ b/test/state/samlp.state.custom.tests.js
@@ -130,7 +130,7 @@ describe('samlp - using custom session state store', function() {
       });
 
       strategy._samlp.validateSamlResponse = function(token, done) {
-        expect(token).to.be.an.object;
+        expect(token).to.be.an('object');
         done(null, { id: '1234' });
       };
       
@@ -160,12 +160,12 @@ describe('samlp - using custom session state store', function() {
         });
 
         it('should supply user', function() {
-          expect(user).to.be.an.object;
+          expect(user).to.be.an('object');
           expect(user.id).to.equal('1234');
         });
 
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Hello');
         });
     
@@ -254,7 +254,7 @@ describe('samlp - using custom session state store', function() {
         });
 
         strategy._samlp.validateSamlResponse = function(token, done) {
-          expect(token).to.be.an.object;
+          expect(token).to.be.an('object');
           done(null, { id: '1234' });
         };
         
@@ -283,14 +283,14 @@ describe('samlp - using custom session state store', function() {
         });
 
         it('should supply user', function() {
-          expect(user).to.be.an.object;
+          expect(user).to.be.an('object');
           expect(user.id).to.equal('1234');
         });
 
         it('should supply info with state', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(Object.keys(info)).to.have.length(1);
-          expect(info.state).to.be.an.object;
+          expect(info.state).to.be.an('object');
           expect(info.state.returnTo).to.equal('http://www.example.com/');
         });
   
@@ -313,7 +313,7 @@ describe('samlp - using custom session state store', function() {
         });
 
         strategy._samlp.validateSamlResponse = function(token, done) {
-          expect(token).to.be.an.object;
+          expect(token).to.be.an('object');
           done(null, { id: '1234' });
         };
 
@@ -342,15 +342,15 @@ describe('samlp - using custom session state store', function() {
         });
 
         it('should supply user', function() {
-          expect(user).to.be.an.object;
+          expect(user).to.be.an('object');
           expect(user.id).to.equal('1234');
         });
 
         it('should supply info with state', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(Object.keys(info)).to.have.length(2);
           expect(info.message).to.equal('Hello');
-          expect(info.state).to.be.an.object;
+          expect(info.state).to.be.an('object');
           expect(info.state.returnTo).to.equal('http://www.example.com/');
         });
   

--- a/test/state/samlp.state.session.tests.js
+++ b/test/state/samlp.state.session.tests.js
@@ -121,7 +121,7 @@ describe('samlp - using default session state store', function() {
       });
 
       strategy._samlp.validateSamlResponse = function(token, done) {
-        expect(token).to.be.an.object;
+        expect(token).to.be.an('object');
         done(null, { id: '1234' });
       };
       
@@ -153,12 +153,12 @@ describe('samlp - using default session state store', function() {
         });
   
         it('should supply user', function() {
-          expect(user).to.be.an.object;
+          expect(user).to.be.an('object');
           expect(user.id).to.equal('1234');
         });
   
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Hello');
         });
       
@@ -196,12 +196,12 @@ describe('samlp - using default session state store', function() {
         });
   
         it('should supply user', function() {
-          expect(user).to.be.an.object;
+          expect(user).to.be.an('object');
           expect(user.id).to.equal('1234');
         });
   
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Hello');
         });
       
@@ -236,7 +236,7 @@ describe('samlp - using default session state store', function() {
         });
   
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Invalid authorization request state.');
         });
       
@@ -272,7 +272,7 @@ describe('samlp - using default session state store', function() {
         });
   
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Unable to verify authorization request state.');
         });
       
@@ -305,7 +305,7 @@ describe('samlp - using default session state store', function() {
         });
   
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Unable to verify authorization request state.');
         });
       
@@ -357,7 +357,7 @@ describe('samlp - using default session state store', function() {
     });
 
     strategy._samlp.validateSamlResponse = function(token, done) {
-      expect(token).to.be.an.object;
+      expect(token).to.be.an('object');
       done(null, { id: '1234' });
     };
     
@@ -423,12 +423,12 @@ describe('samlp - using default session state store', function() {
         });
   
         it('should supply user', function() {
-          expect(user).to.be.an.object;
+          expect(user).to.be.an('object');
           expect(user.id).to.equal('1234');
         });
   
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Hello');
         });
       

--- a/test/state/wsfed.state.custom.tests.js
+++ b/test/state/wsfed.state.custom.tests.js
@@ -125,7 +125,7 @@ describe('wsfed - using custom session state store', function() {
       });
 
       strategy._wsfed.extractToken = function(req) {
-        expect(req).to.be.an.object;
+        expect(req).to.be.an('object');
         return '<trust:RequestedSecurityToken>...</trust:RequestedSecurityToken>';
       };
 
@@ -160,12 +160,12 @@ describe('wsfed - using custom session state store', function() {
         });
 
         it('should supply user', function() {
-          expect(user).to.be.an.object;
+          expect(user).to.be.an('object');
           expect(user.id).to.equal('1234');
         });
 
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Hello');
         });
     
@@ -253,7 +253,7 @@ describe('wsfed - using custom session state store', function() {
         });
 
         strategy._wsfed.extractToken = function(req) {
-          expect(req).to.be.an.object;
+          expect(req).to.be.an('object');
           return '<trust:RequestedSecurityToken>...</trust:RequestedSecurityToken>';
         };
 
@@ -287,14 +287,14 @@ describe('wsfed - using custom session state store', function() {
         });
 
         it('should supply user', function() {
-          expect(user).to.be.an.object;
+          expect(user).to.be.an('object');
           expect(user.id).to.equal('1234');
         });
 
         it('should supply info with state', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(Object.keys(info)).to.have.length(1);
-          expect(info.state).to.be.an.object;
+          expect(info.state).to.be.an('object');
           expect(info.state.returnTo).to.equal('http://www.example.com/');
         });
   
@@ -316,7 +316,7 @@ describe('wsfed - using custom session state store', function() {
         });
 
         strategy._wsfed.extractToken = function(req) {
-          expect(req).to.be.an.object;
+          expect(req).to.be.an('object');
           return '<trust:RequestedSecurityToken>...</trust:RequestedSecurityToken>';
         };
 
@@ -350,15 +350,15 @@ describe('wsfed - using custom session state store', function() {
         });
 
         it('should supply user', function() {
-          expect(user).to.be.an.object;
+          expect(user).to.be.an('object');
           expect(user.id).to.equal('1234');
         });
 
         it('should supply info with state', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(Object.keys(info)).to.have.length(2);
           expect(info.message).to.equal('Hello');
-          expect(info.state).to.be.an.object;
+          expect(info.state).to.be.an('object');
           expect(info.state.returnTo).to.equal('http://www.example.com/');
         });
   

--- a/test/state/wsfed.state.session.tests.js
+++ b/test/state/wsfed.state.session.tests.js
@@ -117,7 +117,7 @@ describe('wsfed - using default session state store', function() {
       });
 
       strategy._wsfed.extractToken = function(req) {
-        expect(req).to.be.an.object;
+        expect(req).to.be.an('object');
         return '<trust:RequestedSecurityToken>...</trust:RequestedSecurityToken>';
       };
 
@@ -154,12 +154,12 @@ describe('wsfed - using default session state store', function() {
         });
   
         it('should supply user', function() {
-          expect(user).to.be.an.object;
+          expect(user).to.be.an('object');
           expect(user.id).to.equal('1234');
         });
   
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Hello');
         });
       
@@ -197,12 +197,12 @@ describe('wsfed - using default session state store', function() {
         });
   
         it('should supply user', function() {
-          expect(user).to.be.an.object;
+          expect(user).to.be.an('object');
           expect(user.id).to.equal('1234');
         });
   
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Hello');
         });
       
@@ -237,7 +237,7 @@ describe('wsfed - using default session state store', function() {
         });
   
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Invalid authorization request state.');
         });
       
@@ -273,7 +273,7 @@ describe('wsfed - using default session state store', function() {
         });
   
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Unable to verify authorization request state.');
         });
       
@@ -306,7 +306,7 @@ describe('wsfed - using default session state store', function() {
         });
   
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Unable to verify authorization request state.');
         });
       
@@ -357,7 +357,7 @@ describe('wsfed - using default session state store', function() {
     });
 
     strategy._wsfed.extractToken = function(req) {
-      expect(req).to.be.an.object;
+      expect(req).to.be.an('object');
       return '<trust:RequestedSecurityToken>...</trust:RequestedSecurityToken>';
     };
 
@@ -428,12 +428,12 @@ describe('wsfed - using default session state store', function() {
         });
   
         it('should supply user', function() {
-          expect(user).to.be.an.object;
+          expect(user).to.be.an('object');
           expect(user.id).to.equal('1234');
         });
   
         it('should supply info', function() {
-          expect(info).to.be.an.object;
+          expect(info).to.be.an('object');
           expect(info.message).to.equal('Hello');
         });
       


### PR DESCRIPTION
### Description

- Drop Node 10 ([No longer maintained](https://nodejs.org/en/about/releases/))
- Add back the missing `--recursive` flag so all tests run
- Add `npm run test-debug` command & VSCode launch config
- Remove `should` (Assertions were being done using 3 different libs, now down to 2)
- Remove `xml2js` (Not used)
- Bump several dev deps
	- mocha
	- chai
	- istanbul -> nyc
	- passport
	- cheerio
- Some var -> const cleanup


### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
