### PR TITLE
Handle encoded CR entities in assertions

### DIFF
--- a/lib/passport-wsfed-saml2/saml.js
+++ b/lib/passport-wsfed-saml2/saml.js
@@ -34,10 +34,12 @@ var SAML = function (options) {
 
 SAML.prototype.validateSignature = function (xml, options, callback) {
   var self = this;
-  xml = utils.parseSamlResponse(xml);
 
   var signaturePath = this.options.signaturePath || options.signaturePath;
-  var signatures = xpath.select(signaturePath, xml);
+  // making a standalone XML doc to run the xpath search
+  // otherwise the search fails with a document fragment (when validating an assertion)
+  var xmlDocForSignatureSearch =  utils.parseSamlResponse(xml.toString())
+  var signatures = xpath.select(signaturePath, xmlDocForSignatureSearch);
   if (signatures.length === 0) {
     return callback(new Error('Signature is missing (xpath: ' + signaturePath + ')'));
   } else if (signatures.length > 1) {
@@ -327,10 +329,10 @@ SAML.prototype.parseAttributes = function (samlAssertion, version) {
 
 SAML.prototype.validateSamlAssertion = function (samlAssertion, callback) {
   var self = this;
+  
+  samlAssertion = utils.parseSamlAssertion(samlAssertion);
 
-  samlAssertion = utils.parseSamlResponse(samlAssertion);
-
-  self.validateSignature(samlAssertion.toString(), {
+  self.validateSignature(samlAssertion, {
     cert: self.options.cert,
     thumbprints: self.options.thumbprints,
     signaturePath: "/*[local-name(.)='Assertion']/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']" }, function(err) {
@@ -346,7 +348,7 @@ SAML.prototype.parseAssertion = function(samlAssertion, callback) {
     samlAssertion = self.options.extractSAMLAssertion(samlAssertion);
   }
 
-  samlAssertion = utils.parseSamlResponse(samlAssertion);
+  samlAssertion = utils.parseSamlAssertion(samlAssertion);
 
   if (!samlAssertion.getAttribute)
     samlAssertion = samlAssertion.documentElement;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-wsfed-saml2",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
     "test": "./node_modules/.bin/mocha --recursive",

--- a/test/samples/plain/samlresponse_cr.xml
+++ b/test/samples/plain/samlresponse_cr.xml
@@ -1,0 +1,49 @@
+<samlp:Response ID="_b2360699-4651-406e-ab81-f048334303ee" Version="2.0" IssueInstant="2021-05-28T20:33:16.991Z" Destination="https://nico-sabena.auth0.com/login/callback" InResponseTo="_986e8f9c130ec4f0fd5625b7e2be26f3"
+  xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">
+  <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">https://sts.windows.net/11111111-1111-1111-1111-111111111111/</Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  <Assertion ID="_5ba08077-903b-46c2-bb1a-994999572c03" IssueInstant="2021-05-28T20:33:16.986Z" Version="2.0" xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
+    <Issuer>https://sts.windows.net/11111111-1111-1111-1111-111111111111/</Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><ds:Reference URI="#_5ba08077-903b-46c2-bb1a-994999572c03"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><ds:DigestValue>5OKsksnrHxum1frjp3ec5/Ir1B7g2XVmdDx3vrkP1Jk=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>CVT7FUdfuiqD0QWvX1EVCVsFuH+czhBYx7yLDEAjm04Cxij9fuYXegWuh8ro8KL28kGcHbRaDcbDJco5Yr5owKdqbXKsqgwwvi0HQqgzBZmEhNgyr35S0omPIUZ89r7JHaYqexyOMibal+rtNqR/hH5whxMZcrlcB/OV+hhA7AwBVjCgB/0TRkjAsUTEjYr1lkDIrNkwFz4omVkBd+0s7d3LgAQNAW98OK3471kLwzcwAL2oT0EOQzaiZUo+Ri1jjawWZImYDwH4A/JdB39U1XQQMlxlFTDKD19Lrf7JVtM7v1pWFTpz0JIjaVoXiPjKO8T1NIkv9fwwSyqyZHMTMA==</ds:SignatureValue><ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIIEDzCCAvegAwIBAgIJALr9HwgrQ7GeMA0GCSqGSIb3DQEBBQUAMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDAeFw0xMjEyMjkxNTMwNDdaFw0xMzAxMjgxNTMwNDdaMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMZiVmNHiXLldrgbS50ONNOH7pJ2zg6OcSMkYZGDZJbOZ/TqwauC6JOnI7+xtkPJsQHZSFJs4U0srjZKzDCmaz2jLAJDShP2jaXlrki16nDLPE//IGAg3BJguSmBCWpDbSm92V9hSsE+Mhx6bDaJiw8yQ+Q8iSm0aTQZtp6O4ICMu00ESdh9NJqIECELvP31ADV1Xhj7IbyyVPDFxMv3ol5BySE9wwwOFUq/wv7Xz9LRiUjUzPO+Lq3OM3o/uCDbk7jD7XrGUuOydALD8ULsXp4EuDO+nFbeXB/iKndZynuVKokirywl2nD2IP0/yncdLQZ8ByIyqP3G82fq/l8p7AsCAwEAAaOBxzCBxDAdBgNVHQ4EFgQUHI2rUXeBjTv1zAllaPGrHFcEK0YwgZQGA1UdIwSBjDCBiYAUHI2rUXeBjTv1zAllaPGrHFcEK0ahZqRkMGIxGDAWBgNVBAMTD2F1dGgwLmF1dGgwLmNvbTESMBAGA1UEChMJQXV0aDAgTExDMQswCQYDVQQGEwJVUzETMBEGA1UECBMKV2FzaGluZ3RvbjEQMA4GA1UEBxMHUmVkbW9uZIIJALr9HwgrQ7GeMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFrXIhCy4T4eGrikb0R2wHv/uS548r3pZyBV0CDbcRwAtbnpJMvkGFqKVp4pmyoIDSVNK/j+sLEshB20XftezHZyRJbCUbtKvXQ6FsxoeZMlN0ITYKTaoBZKhUxxj90otAhNC58qwGUPqt2LewJhHyLucKkGJ1mQ3b5xKZ532ToufouH9VLhig3H1KnxWo/zMD6Ke8cCk6qO9htuhI06s3GQGS1QWQtAmm17C6TfKgDwQFZwhqHUUZnwKRH8gU6OgZsvhgV1B7H5mjZcu57KMiDBekU9MEY0DCVTN3WkmcTII668zLsJrkNX6PEfck1AMBbVE6pEUKcWwq3uaLvlAUo=</ds:X509Certificate></ds:X509Data>"</ds:KeyInfo></ds:Signature>
+    <Subject>
+      <NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">nico@auth0.com</NameID>
+      <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <SubjectConfirmationData InResponseTo="_986e8f9c130ec4f0fd5625b7e2be26f3" NotOnOrAfter="2021-05-28T21:33:16.656Z" Recipient="https://nico-sabena.auth0.com/login/callback"/>
+      </SubjectConfirmation>
+    </Subject>
+    <Conditions NotBefore="2021-05-28T20:28:16.656Z" NotOnOrAfter="2021-05-28T21:33:16.656Z">
+      <AudienceRestriction>
+        <Audience>urn:auth0:nico-sabena:saml-test</Audience>
+      </AudienceRestriction>
+    </Conditions>
+    <AttributeStatement>
+      <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname">
+        <AttributeValue>Nicolas</AttributeValue>
+      </Attribute>
+      <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname">
+        <AttributeValue>Sabena</AttributeValue>
+      </Attribute>
+      <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress">
+        <AttributeValue>nico@auth0.com</AttributeValue>
+      </Attribute>
+      <Attribute Name="country">
+        <AttributeValue>US</AttributeValue>
+      </Attribute>
+      <Attribute Name="displayname">
+        <AttributeValue>Nicolas Sabena</AttributeValue>
+      </Attribute>
+      <Attribute Name="postal_address">
+        <AttributeValue>Street 1&#13;
+Line 2&#13;
+Some more address.&#13;
+City, state and zip goes here.</AttributeValue>
+      </Attribute>
+    </AttributeStatement>
+    <AuthnStatement AuthnInstant="2021-05-28T20:33:12.783Z" SessionIndex="_5ba08077-903b-46c2-bb1a-994999572c03">
+      <AuthnContext>
+        <AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</AuthnContextClassRef>
+      </AuthnContext>
+    </AuthnStatement>
+  </Assertion>
+</samlp:Response>


### PR DESCRIPTION
### Description

This change fixes the calculation of the digest when elements include XML character entities (`&#13;`, `&#xD`), e.g.:

```xml
<AttributeValue>Street 1&#13;
Line 2&#13;
Some more address.&#13;
City, state and zip goes here.
</AttributeValue>
```

Processors are supposed to normalize line endings (`CR`, `CRLF`, `LF`) to `LF` before parsing the XML, but the encoded entities should be converted only after this line ending normalization (so that, in the example above, the carriage return would remain in place).

The code, however, was doing an unnecessary XML doc -> string -> Xml doc conversion when validating a signature in the assertion, which caused these CR characters to be lost. In a simplified way, it was something like this:

```
// first processing of the original XML string
// line endings are normalized
const xmlStringWithNormalizedEndings = normalizeLineEndings(originalXmlString);
// we get this:
// "<AttributeValue>Street 1&#13;\nLine 2&#13;\nSome more address.&#13;\nCity, state and zip goes here.\n</AttributeValue>"

// Now that string is converted to an XML document
const xmlDom = xmldom.DOMParser().parseFromString(xmlStringWithNormalizedEndings);
// character entities are replaced with the characters, so if we look into the XML document now we have this:
// "<AttributeValue>Street 1\r\nLine 2\r\nSome more address.\r\nCity, state and zip goes here.\n</AttributeValue>"

// now we validate the assertion signature:

validateAssertionSignature(xmlDom);
[...]
```

```
function validateAssertionSignature(xmlDoc) {

  // xmlDoc already had normalized line endings, and CR entities converted to the `\r` character.
  // when you do .toString(),the resulting string will have `/r/n` again
  const xmlAsString = xmlDoc.toString();

  // now if you normalize line endings again, the `/r/n` are replaced with `/n`, losing the `/r` chars.
  const xmlStringWithNormalizedLineEndings = normalizeLineEndings(xmlAsString);
  // "<AttributeValue>Street 1\nLine 2\nSome more address.\nCity, state and zip goes here.</AttributeValue>"

  const newDoc =  xmldom.DOMParser().parseFromString(xmlStringWithNormalizedLineEndings);
  // now the newDoc does not have the `/n` characters, and the digest calculation will fail
  [...]
}
```

This fix removes the unnecessary `.toString()` and re-processing of the resulting string.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
