### PR TITLE
Add organization option in query params

### DIFF
--- a/lib/passport-wsfed-saml2/samlp.js
+++ b/lib/passport-wsfed-saml2/samlp.js
@@ -180,6 +180,10 @@ Samlp.prototype = {
       RelayState: options.RelayState || (parsedUrl.query && parsedUrl.query.RelayState) || ''
     };
 
+    if (options.organization) {
+      params.organization = options.organization;
+    }
+
     if (options.protocolBinding === BINDINGS.HTTP_POST || !options.deflate) {
       // HTTP-POST or HTTP-Redirect without deflate encoding
       if (options.signingKey) {
@@ -325,8 +329,8 @@ Samlp.prototype = {
           return done(new Error('Assertion is encrypted. Please set options.decryptionKey with your decryption private key.'));
         }
 
-        return xmlenc.decrypt(encryptedData, { 
-          key: this.options.decryptionKey, 
+        return xmlenc.decrypt(encryptedData, {
+          key: this.options.decryptionKey,
           autopadding: this.options.autopadding,
           disallowDecryptionWithInsecureAlgorithm: false,
           warnInsecureAlgorithm: false


### PR DESCRIPTION
### Description

As a part of shipping SAML support for Organizations, I was using my fork of this library to test. I offer this PR because I think it'll be useful for customers (and our internal use) when we ship that feature.

If you pass `organization` in the options to passport, it will be sent in the query string when submitting the SAMLRequest.

### References

N/A

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
