### PR TITLE
bump xml-encryption to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "uid2": "0.0.x",
     "valid-url": "^1.0.9",
     "xml-crypto": "auth0/xml-crypto#v1.4.1-auth0.2",
-    "xml-encryption": "^1.2.1",
+    "xml-encryption": "^2.0.0",
     "xpath": "0.0.5",
     "xtend": "~2.0.3"
   },


### PR DESCRIPTION
This change drops node 8 (no major bump since the library supports node
10+ anyway), and uses the native node crypto function
instead of node-forge

Version is not bumped yet due to a direct dependency with node-forge. We should also look into using the native crypto library. 

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Addresses node-forge vulnerability: #141

### References

#141

### Testing

No additional tests other than pre-existing ones. 

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
