### PR TITLE
[ULP-3649][ULP-3712] Fix: URL fragments in SAML Sign in URLs

### DIFF
--- a/lib/passport-wsfed-saml2/samlp.js
+++ b/lib/passport-wsfed-saml2/samlp.js
@@ -506,5 +506,5 @@ function generateInstant() {
 }
 
 function stripQueryAndFragmentFromURL(url) {
-  return url.split("?")[0].split("#")[0];
+  return url.split("#")[0].split("?")[0];
 }

--- a/lib/passport-wsfed-saml2/samlp.js
+++ b/lib/passport-wsfed-saml2/samlp.js
@@ -245,7 +245,10 @@ Samlp.prototype = {
       if (err) return callback(err);
 
       var parsedUrl = url.parse(options.identityProviderUrl, true);
-      var samlRequestUrl = options.identityProviderUrl.split('?')[0] + '?' + qs.encode(xtend(parsedUrl.query, params));
+      var samlRequestUrl = stripQueryAndFragmentFromURL(options.identityProviderUrl) + '?' + qs.encode(xtend(parsedUrl.query, params));
+      if (parsedUrl.hash !== null) {
+        samlRequestUrl += parsedUrl.hash;
+      }
       return callback(null, samlRequestUrl);
     });
   },
@@ -500,4 +503,8 @@ Samlp.prototype = {
 function generateInstant() {
   var date = new Date();
   return date.getUTCFullYear() + '-' + ('0' + (date.getUTCMonth()+1)).slice(-2) + '-' + ('0' + date.getUTCDate()).slice(-2) + 'T' + ('0' + date.getUTCHours()).slice(-2) + ":" + ('0' + date.getUTCMinutes()).slice(-2) + ":" + ('0' + date.getUTCSeconds()).slice(-2) + "Z";
+}
+
+function stripQueryAndFragmentFromURL(url) {
+  return url.split("?")[0].split("#")[0];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-wsfed-saml2",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "SAML2 Protocol and WS-Fed library",
   "scripts": {
     "test": "./node_modules/.bin/mocha --recursive",

--- a/test/samlp.tests.js
+++ b/test/samlp.tests.js
@@ -653,6 +653,38 @@ describe('samlp (unit tests)', function () {
         done();
       });
     });
+    it('should return URL fragment at the end after parsing', function(done) {
+      var options = {identityProviderUrl: 'https://example.com#Test'};
+      this.samlp.getSamlRequestUrl(options, function(err, result) {
+        expect(err).to.not.exist;
+        expect(result).to.match(/^https:\/\/example.com\?SAMLRequest=.*&RelayState=.*\#Test/);
+        done();
+      });
+    });
+    it('should return multiple URL fragments at the end after parsing', function(done) {
+      var options = {identityProviderUrl: 'https://example.com#param1=value1&param2=value'};
+      this.samlp.getSamlRequestUrl(options, function(err, result) {
+        expect(err).to.not.exist;
+        expect(result).to.match(/^https:\/\/example.com\?SAMLRequest=.*&RelayState=.*\#param1=value1&param2=value/);
+        done();
+      });
+    });
+    it('should return URL query and fragments in correct order after parsing', function(done) {
+      var options = {identityProviderUrl: 'https://example.com?ABC=123#Test'};
+      this.samlp.getSamlRequestUrl(options, function(err, result) {
+        expect(err).to.not.exist;
+        expect(result).to.match(/^https:\/\/example.com\?ABC=123&SAMLRequest=.*&RelayState=.*\#Test/);
+        done();
+      });
+    });
+    it('should return URL query and multiple fragments in correct order after parsing', function(done) {
+      var options = {identityProviderUrl: 'https://example.com?ABC=123#param1=value1&param2=value'};
+      this.samlp.getSamlRequestUrl(options, function(err, result) {
+        expect(err).to.not.exist;
+        expect(result).to.match(/^https:\/\/example.com\?ABC=123&SAMLRequest=.*&RelayState=.*\#param1=value1&param2=value/);
+        done();
+      });
+    });
   });
 
   describe('getSamlStatus', function(){

--- a/test/samlp.tests.js
+++ b/test/samlp.tests.js
@@ -654,34 +654,34 @@ describe('samlp (unit tests)', function () {
       });
     });
     it('should return URL fragment at the end after parsing', function(done) {
-      var options = {identityProviderUrl: 'https://example.com#Test'};
+      var options = {identityProviderUrl: 'https://example.com/#Test'};
       this.samlp.getSamlRequestUrl(options, function(err, result) {
         expect(err).to.not.exist;
-        expect(result).to.match(/^https:\/\/example.com\?SAMLRequest=.*&RelayState=.*\#Test/);
+        expect(result).to.match(/^https:\/\/example.com\/\?SAMLRequest=.*&RelayState=.*\#Test/);
         done();
       });
     });
     it('should return multiple URL fragments at the end after parsing', function(done) {
-      var options = {identityProviderUrl: 'https://example.com#param1=value1&param2=value'};
+      var options = {identityProviderUrl: 'https://example.com/#param1=value1&param2=value'};
       this.samlp.getSamlRequestUrl(options, function(err, result) {
         expect(err).to.not.exist;
-        expect(result).to.match(/^https:\/\/example.com\?SAMLRequest=.*&RelayState=.*\#param1=value1&param2=value/);
+        expect(result).to.match(/^https:\/\/example.com\/\?SAMLRequest=.*&RelayState=.*\#param1=value1&param2=value/);
         done();
       });
     });
     it('should return URL query and fragments in correct order after parsing', function(done) {
-      var options = {identityProviderUrl: 'https://example.com?ABC=123#Test'};
+      var options = {identityProviderUrl: 'https://example.com/?ABC=123#Test'};
       this.samlp.getSamlRequestUrl(options, function(err, result) {
         expect(err).to.not.exist;
-        expect(result).to.match(/^https:\/\/example.com\?ABC=123&SAMLRequest=.*&RelayState=.*\#Test/);
+        expect(result).to.match(/^https:\/\/example.com\/\?ABC=123&SAMLRequest=.*&RelayState=.*\#Test/);
         done();
       });
     });
     it('should return URL query and multiple fragments in correct order after parsing', function(done) {
-      var options = {identityProviderUrl: 'https://example.com?ABC=123#param1=value1&param2=value'};
+      var options = {identityProviderUrl: 'https://example.com/?ABC=123#param1=value1&param2=value'};
       this.samlp.getSamlRequestUrl(options, function(err, result) {
         expect(err).to.not.exist;
-        expect(result).to.match(/^https:\/\/example.com\?ABC=123&SAMLRequest=.*&RelayState=.*\#param1=value1&param2=value/);
+        expect(result).to.match(/^https:\/\/example.com\/\?ABC=123&SAMLRequest=.*&RelayState=.*\#param1=value1&param2=value/);
         done();
       });
     });


### PR DESCRIPTION
### Description
**Purpose**:  This PR solves an existing bug in SAML request URL construction during sign in. If the URL contains any fragments, the fragments are not always appended at the end of the URL after all the query params. 

Eg: When parsing https://example.com/#Test. 
- Actual: https://example.com/#Test?SAMLRequest=...&RelayState=...
- Expected:  https://example.com/?SAMLRequest=...&RelayState=...#Test

The PR solves the problem by stripping fragments and query from URL and then appending them in the correct order after parsing stage.


### References

ESD Ticket: https://auth0team.atlassian.net/browse/ESD-19892 for more context

### Testing
Added Unit tests for this fix covering typical URL examples with/without fragments & with/without query params

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs -> Not Applicable for this change
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
