### PR TITLE
FDR-457 - Do not allow tokens to have more than one assertion for WS-Fed

### DIFF
--- a/lib/passport-wsfed-saml2/wsfederation.js
+++ b/lib/passport-wsfed-saml2/wsfederation.js
@@ -59,6 +59,12 @@ WsFederation.prototype = {
       return callback(new Error('missing RequestedSecurityToken element'));
     }
 
+    // Check for more than one Assertions to conform with spec
+    var foundAssertions = xpath.select("//*[local-name(.)='Assertion']", token);
+    if (foundAssertions.length > 1) {
+      return callback(new Error('A RequestedSecurityToken can contain only one Assertion element.'));
+    }
+
     callback(null, token);
   },
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR is to validate if we have more than one Assertion inside a token response for WS-Fed. This validation will ensure we're compliant with WS-Trust specs. 


### References

https://auth0team.atlassian.net/browse/FDR-457

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
